### PR TITLE
Make libretro cores part of the bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ ludo
 ludo.exe
 settings.json
 Ludo.app
+Ludo.dmg
+cores

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ script:
   - megacheck ./...
   - gocyclo -over 19 $GO_FILES
   - golint -set_exit_status $(go list ./...)
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then OS="Linux" VERSION=${TRAVIS_TAG:1} make tar; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then OS="OSX" VERSION=${TRAVIS_TAG:1} make dmg; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then OS="Windows" VERSION=${TRAVIS_TAG:1} make zip; fi
+  - if [[ -n "$TRAVIS_TAG" -a "$TRAVIS_OS_NAME" == "linux" ]]; then OS="Linux" VERSION=${TRAVIS_TAG:1} make tar; fi
+  - if [[ -n "$TRAVIS_TAG" -a "$TRAVIS_OS_NAME" == "osx" ]]; then OS="OSX" VERSION=${TRAVIS_TAG:1} make dmg; fi
+  - if [[ -n "$TRAVIS_TAG" -a "$TRAVIS_OS_NAME" == "windows" ]]; then OS="Windows" VERSION=${TRAVIS_TAG:1} make zip; fi
 
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ script:
   - megacheck ./...
   - gocyclo -over 19 $GO_FILES
   - golint -set_exit_status $(go list ./...)
-  - if [[ -n "$TRAVIS_TAG" -a "$TRAVIS_OS_NAME" == "linux" ]]; then OS="Linux" VERSION=${TRAVIS_TAG:1} make tar; fi
-  - if [[ -n "$TRAVIS_TAG" -a "$TRAVIS_OS_NAME" == "osx" ]]; then OS="OSX" VERSION=${TRAVIS_TAG:1} make dmg; fi
-  - if [[ -n "$TRAVIS_TAG" -a "$TRAVIS_OS_NAME" == "windows" ]]; then OS="Windows" VERSION=${TRAVIS_TAG:1} make zip; fi
+  - if [[ -n "$TRAVIS_TAG" && "$TRAVIS_OS_NAME" == "linux" ]]; then OS="Linux" VERSION=${TRAVIS_TAG:1} make tar; fi
+  - if [[ -n "$TRAVIS_TAG" && "$TRAVIS_OS_NAME" == "osx" ]]; then OS="OSX" VERSION=${TRAVIS_TAG:1} make dmg; fi
+  - if [[ -n "$TRAVIS_TAG" && "$TRAVIS_OS_NAME" == "windows" ]]; then OS="Windows" VERSION=${TRAVIS_TAG:1} make zip; fi
 
 deploy:
   skip_cleanup: true

--- a/menu/scene_main.go
+++ b/menu/scene_main.go
@@ -35,7 +35,7 @@ func buildMainMenu() Scene {
 		callbackOK: func() {
 			list.segueNext()
 			menu.stack = append(menu.stack, buildExplorer(
-				usr.HomeDir,
+				"cores",
 				[]string{".dll", ".dylib", ".so"},
 				core.Load,
 				nil,

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -104,8 +104,7 @@ func Save() error {
 // CoreForPlaylist returns the absolute path of the default libretro core for
 // a given playlist
 func CoreForPlaylist(playlist string) (string, error) {
-	usr, _ := user.Current()
-	coresPath := usr.HomeDir + "/.ludo/cores/"
+	coresPath := "cores/"
 	c := Settings.CoreForPlaylist[playlist]
 	if c != "" {
 		return coresPath + c + utils.CoreExt(), nil


### PR DESCRIPTION
This change avoids the need for a core updater, so the user just has to care about getting games.
Less steps are required in order to play.