### PR TITLE
Add ability to launch core without content

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -78,11 +78,10 @@ func Load(sofile string) error {
 
 	menu.UpdateOptions(opts)
 
-	if (state.Global.SupportNoGame) {
+	if state.Global.SupportNoGame {
 		log.Println("[Core]: Core launching: " + si.LibraryName)
 		StartCore()
-	}
-	else {
+	} else {
 		log.Println("[Core]: Core loaded: " + si.LibraryName)
 	}
 

--- a/core/environment.go
+++ b/core/environment.go
@@ -47,6 +47,8 @@ func environment(cmd uint32, data unsafe.Pointer) bool {
 		state.Global.FrameTimeCb = libretro.SetFrameTimeCallback(data)
 	case libretro.EnvironmentSetAudioCallback:
 		state.Global.AudioCb = libretro.SetAudioCallback(data)
+	case libretro.EnvironmentSetSupportNoGame:
+		state.Global.SupportNoGame = libretro.GetBool(data)
 	case libretro.EnvironmentGetCanDupe:
 		libretro.SetBool(data, true)
 	case libretro.EnvironmentSetPixelFormat:

--- a/libretro/libretro.go
+++ b/libretro/libretro.go
@@ -169,6 +169,7 @@ const (
 	EnvironmentGetUsername          = uint32(C.RETRO_ENVIRONMENT_GET_USERNAME)
 	EnvironmentGetLogInterface      = uint32(C.RETRO_ENVIRONMENT_GET_LOG_INTERFACE)
 	EnvironmentGetCanDupe           = uint32(C.RETRO_ENVIRONMENT_GET_CAN_DUPE)
+	EnvironmentSetSupportNoGame     = uint32(C.RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME)
 	EnvironmentSetPixelFormat       = uint32(C.RETRO_ENVIRONMENT_SET_PIXEL_FORMAT)
 	EnvironmentGetSystemDirectory   = uint32(C.RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY)
 	EnvironmentGetSaveDirectory     = uint32(C.RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY)
@@ -512,6 +513,12 @@ func GetVariables(data unsafe.Pointer) []Variable {
 func SetBool(data unsafe.Pointer, val bool) {
 	b := (*C.bool)(data)
 	*b = C.bool(val)
+}
+
+// GetBool is an environment callback helper to get a boolean
+func GetBool(data unsafe.Pointer) bool {
+	b := (*C.bool)(data)
+	return (bool)(*b)
 }
 
 // SetString is an environment callback helper to set a string

--- a/state/state.go
+++ b/state/state.go
@@ -12,6 +12,7 @@ type State struct {
 	Core        libretro.Core // Current libretro core
 	FrameTimeCb libretro.FrameTimeCallback
 	AudioCb     libretro.AudioCallback
+	SupportNoGame bool // When set to true, the core doesn't require content to run
 	CoreRunning bool
 	MenuActive  bool // When set to true, will display the menu layer
 	Verbose     bool


### PR DESCRIPTION
This allows loading cores that do not require content to run. This allows running the following cores in Ludo....
- 2048
- Mr.Boom
- ScummVM

## TODO

- [ ] Fix segfault that happens when launching a no game core, like 2048

```
2019/01/01 12:25:41 [DEBUG]: retro_init
2019/01/01 12:25:41 [Core]: Core launching: Mr.Boom
2019/01/01 12:25:41 [OpenAL]: Using 4 buffers of 4096 bytes.
panic: runtime error: index out of range

goroutine 1 [running, locked to thread]:
github.com/libretro/ludo/input.State(0x5, 0xc400000001, 0x0, 0x0, 0xc425e81c78)
	/home/rob/.gocode/src/github.com/libretro/ludo/input/input.go:141 +0x88
github.com/libretro/ludo/libretro.coreInputState(0x100000005, 0x0, 0xc425e81cb8)
	/home/rob/.gocode/src/github.com/libretro/ludo/libretro/libretro.go:448 +0x50
github.com/libretro/ludo/libretro._cgoexpwrap_7b63558b42b1_coreInputState(0x100000005, 0x0, 0x7f44a8c80000)
	_cgo_gotypes.go:653 +0x41
github.com/libretro/ludo/libretro._Cfunc_bridge_retro_run(0x7f44a865cf80)
	_cgo_gotypes.go:404 +0x41
github.com/libretro/ludo/libretro.(*Core).Run.func1(0x7f44a865cf80)
	/home/rob/.gocode/src/github.com/libretro/ludo/libretro/libretro.go:275 +0x56
github.com/libretro/ludo/libretro.(*Core).Run(0xbe8ec0)
	/home/rob/.gocode/src/github.com/libretro/ludo/libretro/libretro.go:275 +0x2f
main.runLoop(0xc42012e310)
	/home/rob/.gocode/src/github.com/libretro/ludo/main.go:31 +0xb8
main.main()
	/home/rob/.gocode/src/github.com/libretro/ludo/main.go:112 +0x41f
```

## QA

1. Launch ludo
2. Load Core
3. Select 2048

## References
- Fixes #58