### PR TITLE
Add retro_set_controller_port_device()

### DIFF
--- a/libretro/cfuncs.go
+++ b/libretro/cfuncs.go
@@ -46,6 +46,10 @@ void bridge_retro_set_video_refresh(void *f, void *callback) {
 	((bool (*)(retro_video_refresh_t))f)((retro_video_refresh_t)callback);
 }
 
+void bridge_retro_set_controller_port_device(void *f, unsigned port, unsigned device) {
+	return ((void (*)(unsigned, unsigned))f)(port, device);
+}
+
 void bridge_retro_set_input_poll(void *f, void *callback) {
 	((bool (*)(retro_input_poll_t))f)((retro_input_poll_t)callback);
 }

--- a/libretro/libretro.go
+++ b/libretro/libretro.go
@@ -20,6 +20,7 @@ void bridge_retro_get_system_info(void *f, struct retro_system_info *si);
 void bridge_retro_get_system_av_info(void *f, struct retro_system_av_info *si);
 bool bridge_retro_set_environment(void *f, void *callback);
 void bridge_retro_set_video_refresh(void *f, void *callback);
+void bridge_retro_set_controller_port_device(void *f, unsigned port, unsigned device);
 void bridge_retro_set_input_poll(void *f, void *callback);
 void bridge_retro_set_input_state(void *f, void *callback);
 void bridge_retro_set_audio_sample(void *f, void *callback);
@@ -243,6 +244,7 @@ func Load(sofile string) (*Core, error) {
 	core.symRetroGetSystemAVInfo = core.DlSym("retro_get_system_av_info")
 	core.symRetroSetEnvironment = core.DlSym("retro_set_environment")
 	core.symRetroSetVideoRefresh = core.DlSym("retro_set_video_refresh")
+	core.symRetroSetControllerPortDevice = core.DlSym("retro_set_controller_port_device")
 	core.symRetroSetInputPoll = core.DlSym("retro_set_input_poll")
 	core.symRetroSetInputState = core.DlSym("retro_set_input_state")
 	core.symRetroSetAudioSample = core.DlSym("retro_set_audio_sample")
@@ -450,6 +452,11 @@ func coreInputPoll() {
 		return
 	}
 	inputPoll()
+}
+
+//export SetControllerPortDevice
+func (core *Core) SetControllerPortDevice(port uint, device uint) {
+	C.bridge_retro_set_controller_port_device(core.symRetroSetControllerPortDevice, C.unsigned(port), C.unsigned(device))
 }
 
 //export coreInputState

--- a/libretro/libretro_notwindows.go
+++ b/libretro/libretro_notwindows.go
@@ -25,6 +25,7 @@ type Core struct {
 	symRetroGetSystemAVInfo     unsafe.Pointer
 	symRetroSetEnvironment      unsafe.Pointer
 	symRetroSetVideoRefresh     unsafe.Pointer
+	symRetroSetControllerPortDevice unsafe.Pointer
 	symRetroSetInputPoll        unsafe.Pointer
 	symRetroSetInputState       unsafe.Pointer
 	symRetroSetAudioSample      unsafe.Pointer

--- a/libretro/libretro_windows.go
+++ b/libretro/libretro_windows.go
@@ -16,6 +16,7 @@ type Core struct {
 	symRetroGetSystemAVInfo     unsafe.Pointer
 	symRetroSetEnvironment      unsafe.Pointer
 	symRetroSetVideoRefresh     unsafe.Pointer
+	symRetroSetControllerPortDevice unsafe.Pointer
 	symRetroSetInputPoll        unsafe.Pointer
 	symRetroSetInputState       unsafe.Pointer
 	symRetroSetAudioSample      unsafe.Pointer

--- a/main.go
+++ b/main.go
@@ -111,6 +111,9 @@ func main() {
 		}
 	}
 
+	// Set the device inputs, after the game is loaded so that devices are available.
+	core.SetControllerPortDevice(0, 1)
+
 	// No game running? display the menu
 	state.Global.MenuActive = !state.Global.CoreRunning
 


### PR DESCRIPTION
This aims to fix https://github.com/libretro/ludo/issues/115

@kivutar I think something is wrong with the callbacks here. Mind having a look?
```
# github.com/libretro/ludo/libretro
libretro/libretro_notwindows.go:18:11: Go type not supported in export: struct {
	handle	unsafe.Pointer

	symRetroInit			unsafe.Pointer
	symRetroDeinit			unsafe.Pointer
	symRetroAPIVersion		unsafe.Pointer
	symRetroGetSystemInfo		unsafe.Pointer
	symRetroGetSystemAVInfo		unsafe.Pointer
	symRetroSetEnvironment		unsafe.Pointer
	symRetroSetVideoRefresh		unsafe.Pointer
	symRetroSetControllerPortDevice	unsafe.Pointer
	symRetroSetInputPoll		unsafe.Pointer
	symRetroSetInputState		unsafe.Pointer
	symRetroSetAudioSample		unsafe.Pointer
	symRetroSetAudioSampleBatch	unsafe.Pointer
	symRetroRun			unsafe.Pointer
	symRetroReset			unsafe.Pointer
	symRetroLoadGame		unsafe.Pointer
	symRetroUnloadGame		unsafe.Pointer
	symRetroSerializeSize		unsafe.Pointer
	symRetroSerialize		unsafe.Pointer
	symRetroUnserialize		unsafe.Pointer
	symRetroGetMemorySize		unsafe.Pointer
	symRetroGetMemoryData		unsafe.Pointer

	AudioCallback		*AudioCallback
	FrameTimeCallback	*FrameTimeCallback
}
libretro/libretro_notwindows.go:18:11: Go type not supported in export: struct {
	handle	unsafe.Pointer

	symRetroInit			unsafe.Pointer
	symRetroDeinit			unsafe.Pointer
	symRetroAPIVersion		unsafe.Pointer
	symRetroGetSystemInfo		unsafe.Pointer
	symRetroGetSystemAVInfo		unsafe.Pointer
	symRetroSetEnvironment		unsafe.Pointer
	symRetroSetVideoRefresh		unsafe.Pointer
	symRetroSetControllerPortDevice	unsafe.Pointer
	symRetroSetInputPoll		unsafe.Pointer
	symRetroSetInputState		unsafe.Pointer
	symRetroSetAudioSample		unsafe.Pointer
	symRetroSetAudioSampleBatch	unsafe.Pointer
	symRetroRun			unsafe.Pointer
	symRetroReset			unsafe.Pointer
	symRetroLoadGame		unsafe.Pointer
	symRetroUnloadGame		unsafe.Pointer
	symRetroSerializeSize		unsafe.Pointer
	symRetroSerialize		unsafe.Pointer
	symRetroUnserialize		unsafe.Pointer
	symRetroGetMemorySize		unsafe.Pointer
	symRetroGetMemoryData		unsafe.Pointer

	AudioCallback		*AudioCallback
	FrameTimeCallback	*FrameTimeCallback
}

```