### PR TITLE
Display consistent system names

### DIFF
--- a/menu/scene_tabs.go
+++ b/menu/scene_tabs.go
@@ -132,8 +132,10 @@ func getPlaylists() []entry {
 		path := path
 		filename := utils.FileName(path)
 		count := playlists.Count(path)
+		label := playlists.RemoveVendor(filename)
+		label = playlists.ShortName(label)
 		pls = append(pls, entry{
-			label:    playlists.ShortName(filename),
+			label:    label,
 			subLabel: fmt.Sprintf("%d Games - 0 Favorites", count),
 			icon:     filename,
 			callbackOK: func() {

--- a/menu/scene_tabs.go
+++ b/menu/scene_tabs.go
@@ -132,8 +132,7 @@ func getPlaylists() []entry {
 		path := path
 		filename := utils.FileName(path)
 		count := playlists.Count(path)
-		label := playlists.RemoveVendor(filename)
-		label = playlists.ShortName(label)
+		label := playlists.ShortName(filename)
 		pls = append(pls, entry{
 			label:    label,
 			subLabel: fmt.Sprintf("%d Games - 0 Favorites", count),

--- a/playlists/playlists.go
+++ b/playlists/playlists.go
@@ -93,9 +93,13 @@ func ShortName(in string) string {
 	if len(in) < 20 {
 		return in
 	}
-	r, _ := regexp.Compile(`(.*?) - (.*)`)
-	out := r.ReplaceAllString(in, "$2")
-	out = strings.Replace(out, "Nintendo Entertainment System", "NES", -1)
+	out := strings.Replace(in, "Nintendo Entertainment System", "NES", -1)
 	out = strings.Replace(out, "PC Engine", "PCE", -1)
 	return out
+}
+
+// RemoveVendor removes the vendor prefix from a game system name
+func RemoveVendor(in string) string {
+	r, _ := regexp.Compile(`(.*?) - (.*)`)
+	return r.ReplaceAllString(in, "$2")
 }

--- a/playlists/playlists.go
+++ b/playlists/playlists.go
@@ -134,6 +134,10 @@ func ShortName(in string) string {
 		"The 3DO Company - 3DO":                          "3DO",
 		"Uzebox":                                         "Uzebox",
 	}
-	
-	return shortNames[in]
+
+	out, ok := shortNames[in]
+	if !ok {
+		return in
+	}
+	return out
 }

--- a/playlists/playlists.go
+++ b/playlists/playlists.go
@@ -10,9 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/libretro/ludo/settings"
 )
@@ -90,16 +88,52 @@ func Count(path string) int {
 // ShortName shortens the name of some game systems that are too long to be
 // displayed in the menu
 func ShortName(in string) string {
-	if len(in) < 20 {
-		return in
+	shortNames := map[string]string{
+		"Atari - 2600":                                   "Atari 2600",
+		"Atari - 5200":                                   "Atari 5200",
+		"Atari - 7800":                                   "Atari 7800",
+		"Atari - Jaguar":                                 "Atari Jaguar",
+		"Atari - Lynx":                                   "Atari Lynx",
+		"Atari - ST":                                     "Atari ST",
+		"Bandai - WonderSwan Color":                      "WonderSwan Color",
+		"Bandai - WonderSwan":                            "WonderSwan",
+		"Coleco - ColecoVision":                          "ColecoVision",
+		"Commodore - 64":                                 "Commodore 64",
+		"FB Alpha - Arcade Games":                        "Arcade (FB Alpha)",
+		"GCE - Vectrex":                                  "Vectrex",
+		"Magnavox - Odyssey2":                            "Magnavox Odyssey²",
+		"Microsoft - MSX":                                "MSX",
+		"Microsoft - MSX2":                               "MSX2",
+		"NEC - PC Engine - TurboGrafx 16":                "TurboGrafx-16",
+		"NEC - PC Engine CD - TurboGrafx-CD":             "TurboGrafx-CD",
+		"NEC - PC Engine SuperGrafx":                     "SuperGrafx",
+		"NEC - PC-FX":                                    "PC-FX",
+		"Nintendo - Family Computer Disk System":         "Famicom Disk System",
+		"Nintendo - Game Boy Advance":                    "Game Boy Advance",
+		"Nintendo - Game Boy Color":                      "Game Boy Color",
+		"Nintendo - Game Boy":                            "Game Boy",
+		"Nintendo - Nintendo Entertainment System":       "NES",
+		"Nintendo - Pokemon Mini":                        "Pokémon Mini",
+		"Nintendo - Super Nintendo Entertainment System": "SNES",
+		"Nintendo - Virtual Boy":                         "Virtual Boy",
+		"Sega - 32X":                                     "32X",
+		"Sega - Game Gear":                               "Game Gear",
+		"Sega - Master System - Mark III":                "Master System",
+		"Sega - Mega Drive - Genesis":                    "Mega Drive/Genesis",
+		"Sega - PICO":                                    "Pico",
+		"Sega - Saturn":                                  "Saturn",
+		"Sega - SG-1000":                                 "SG-1000",
+		"Sharp - X68000":                                 "X68000",
+		"Sinclair - ZX 81":                               "ZX81",
+		"Sinclair - ZX Spectrum +3":                      "ZX Spectrum +3",
+		"Sinclair - ZX Spectrum":                         "ZX Spectrum",
+		"SNK - Neo Geo CD":                               "Neo Geo CD",
+		"SNK - Neo Geo Pocket Color":                     "Neo Geo Pocket Color",
+		"SNK - Neo Geo Pocket":                           "Neo Geo Pocket",
+		"Sony - PlayStation":                             "PlayStation",
+		"The 3DO Company - 3DO":                          "3DO",
+		"Uzebox":                                         "Uzebox",
 	}
-	out := strings.Replace(in, "Nintendo Entertainment System", "NES", -1)
-	out = strings.Replace(out, "PC Engine", "PCE", -1)
-	return out
-}
-
-// RemoveVendor removes the vendor prefix from a game system name
-func RemoveVendor(in string) string {
-	r, _ := regexp.Compile(`(.*?) - (.*)`)
-	return r.ReplaceAllString(in, "$2")
+	
+	return shortNames[in]
 }

--- a/playlists/playlists_test.go
+++ b/playlists/playlists_test.go
@@ -99,28 +99,28 @@ func TestShortName(t *testing.T) {
 		{
 			name: "Should change nothing",
 			args: args{
-				in: "Sega - 32X",
+				in: "32X",
 			},
-			want: "Sega - 32X",
+			want: "32X",
 		},
 		{
-			name: "Should skip the vendor",
+			name: "Should change nothing",
 			args: args{
-				in: "FB Alpha - Arcade Games",
+				in: "Arcade Games",
 			},
 			want: "Arcade Games",
 		},
 		{
 			name: "Should replace with acronym",
 			args: args{
-				in: "NEC - PC Engine - TurboGrafx 16",
+				in: "PC Engine - TurboGrafx 16",
 			},
 			want: "PCE - TurboGrafx 16",
 		},
 		{
 			name: "Should replace with acronym",
 			args: args{
-				in: "Nintendo - Super Nintendo Entertainment System",
+				in: "Super Nintendo Entertainment System",
 			},
 			want: "Super NES",
 		},
@@ -129,6 +129,53 @@ func TestShortName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ShortName(tt.args.in); got != tt.want {
 				t.Errorf("ShortName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveVendor(t *testing.T) {
+	type args struct {
+		in string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Should remove vendor prefix",
+			args: args{
+				in: "Sega - 32X",
+			},
+			want: "32X",
+		},
+		{
+			name: "Should remove vendor prefix",
+			args: args{
+				in: "FB Alpha - Arcade Games",
+			},
+			want: "Arcade Games",
+		},
+		{
+			name: "Should remove vendor prefix",
+			args: args{
+				in: "NEC - PC Engine - TurboGrafx 16",
+			},
+			want: "PC Engine - TurboGrafx 16",
+		},
+		{
+			name: "Should remove vendor prefix",
+			args: args{
+				in: "Nintendo - Super Nintendo Entertainment System",
+			},
+			want: "Super Nintendo Entertainment System",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RemoveVendor(tt.args.in); got != tt.want {
+				t.Errorf("RemoveVendor() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/playlists/playlists_test.go
+++ b/playlists/playlists_test.go
@@ -97,85 +97,38 @@ func TestShortName(t *testing.T) {
 		want string
 	}{
 		{
-			name: "Should change nothing",
-			args: args{
-				in: "32X",
-			},
-			want: "32X",
-		},
-		{
-			name: "Should change nothing",
-			args: args{
-				in: "Arcade Games",
-			},
-			want: "Arcade Games",
-		},
-		{
-			name: "Should replace with acronym",
-			args: args{
-				in: "PC Engine - TurboGrafx 16",
-			},
-			want: "PCE - TurboGrafx 16",
-		},
-		{
-			name: "Should replace with acronym",
-			args: args{
-				in: "Super Nintendo Entertainment System",
-			},
-			want: "Super NES",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ShortName(tt.args.in); got != tt.want {
-				t.Errorf("ShortName() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestRemoveVendor(t *testing.T) {
-	type args struct {
-		in string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "Should remove vendor prefix",
+			name: "Should remove vendor",
 			args: args{
 				in: "Sega - 32X",
 			},
 			want: "32X",
 		},
 		{
-			name: "Should remove vendor prefix",
+			name: "Should specify vendor as additional information",
 			args: args{
 				in: "FB Alpha - Arcade Games",
 			},
-			want: "Arcade Games",
+			want: "Arcade (FB Alpha)",
 		},
 		{
-			name: "Should remove vendor prefix",
+			name: "Should remove vendor and alternative name",
 			args: args{
 				in: "NEC - PC Engine - TurboGrafx 16",
 			},
-			want: "PC Engine - TurboGrafx 16",
+			want: "TurboGrafx-16",
 		},
 		{
-			name: "Should remove vendor prefix",
+			name: "Should replace with acronym",
 			args: args{
 				in: "Nintendo - Super Nintendo Entertainment System",
 			},
-			want: "Super Nintendo Entertainment System",
+			want: "SNES",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := RemoveVendor(tt.args.in); got != tt.want {
-				t.Errorf("RemoveVendor() = %v, want %v", got, tt.want)
+			if got := ShortName(tt.args.in); got != tt.want {
+				t.Errorf("ShortName() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
In the current version, long system names skip the vendor name prefix and short names don't. With this pull request, all systems skip the vendor names, making the displayed names more consistent.