### PR TITLE
Fix interpolation at image border

### DIFF
--- a/video/video.go
+++ b/video/video.go
@@ -256,6 +256,8 @@ func (video *Video) UpdateFilter(filter string) {
 		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
 		video.program = video.defaultProgram
 	}
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 	gl.UseProgram(video.program)
 	gl.Uniform2f(gl.GetUniformLocation(video.program, gl.Str("TextureSize\x00")), float32(video.width), float32(video.height))
 	gl.Uniform2f(gl.GetUniformLocation(video.program, gl.Str("InputSize\x00")), float32(video.width), float32(video.height))


### PR DESCRIPTION
These changes set the texture wrap to clamp and fixes the issue shown below.

![texture-wrap-issue](https://user-images.githubusercontent.com/11963815/69976337-1d70de00-1529-11ea-93c6-6f781ca09e29.png)
(green parts are interpolated to the other side in red, due to texture wrap's initial state repeat)

This problem depends on the resolution and is not always visible, but the higher the resolution, the more obvious.