### PR TITLE
Limit rotation value (#299)

### DIFF
--- a/video/video.go
+++ b/video/video.go
@@ -256,6 +256,8 @@ func (video *Video) UpdateFilter(filter string) {
 		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
 		video.program = video.defaultProgram
 	}
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 	gl.UseProgram(video.program)
 	gl.Uniform2f(gl.GetUniformLocation(video.program, gl.Str("TextureSize\x00")), float32(video.width), float32(video.height))
 	gl.Uniform2f(gl.GetUniformLocation(video.program, gl.Str("InputSize\x00")), float32(video.width), float32(video.height))

--- a/video/video.go
+++ b/video/video.go
@@ -398,7 +398,13 @@ func (video *Video) Refresh(data unsafe.Pointer, width int32, height int32, pitc
 
 // SetRotation rotates the game image as requested by the core
 func (video *Video) SetRotation(rot uint) bool {
-	video.rot = rot
+	// limit to valid values (0, 1, 2, 3, which rotates screen by 0, 90, 180 270 degrees counter-clockwise)
+	video.rot = rot % 4
+
+	if state.Global.Verbose {
+		log.Printf("[Video]: Set Rotation: %v", video.rot)
+	}
+
 	return true
 }
 


### PR DESCRIPTION
This limits the applied rotation to the valid values of 0, 1, 2, 3 and also fixes #299.