### PR TITLE
Fix thumbs, tags and FB Alpha to FBNeo

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func main() {
 		log.Println("Can't load game database:", err)
 	}
 
+	playlists.Update()
 	playlists.Load()
 
 	history.Load()

--- a/menu/scene_history.go
+++ b/menu/scene_history.go
@@ -171,14 +171,16 @@ func (s *sceneHistory) render() {
 			stack += 10
 
 			for _, tag := range e.tags {
-				stack += 20
-				vid.DrawImage(
-					menu.icons[tag],
-					stack, float32(h)*e.yp-22*menu.ratio-slOffset,
-					60*menu.ratio, 44*menu.ratio, 1.0, video.Color{R: 1, G: 1, B: 1, A: e.tagAlpha})
-				vid.DrawBorder(stack, float32(h)*e.yp-22*menu.ratio-slOffset,
-					60*menu.ratio, 44*menu.ratio, 0.05/menu.ratio, video.Color{R: 0, G: 0, B: 0, A: e.tagAlpha / 4})
-				stack += 60 * menu.ratio
+				if _, ok := menu.icons[tag]; ok {
+					stack += 20
+					vid.DrawImage(
+						menu.icons[tag],
+						stack, float32(h)*e.yp-22*menu.ratio-slOffset,
+						60*menu.ratio, 44*menu.ratio, 1.0, video.Color{R: 1, G: 1, B: 1, A: e.tagAlpha})
+					vid.DrawBorder(stack, float32(h)*e.yp-22*menu.ratio-slOffset,
+						60*menu.ratio, 44*menu.ratio, 0.05/menu.ratio, video.Color{R: 0, G: 0, B: 0, A: e.tagAlpha / 4})
+					stack += 60 * menu.ratio
+				}
 			}
 
 			vid.Font.SetColor(0.5, 0.5, 0.5, e.subLabelAlpha)

--- a/menu/scene_playlist.go
+++ b/menu/scene_playlist.go
@@ -200,14 +200,16 @@ func (s *scenePlaylist) render() {
 			stack += 10
 
 			for _, tag := range e.tags {
-				stack += 20
-				vid.DrawImage(
-					menu.icons[tag],
-					stack, float32(h)*e.yp-22*menu.ratio,
-					60*menu.ratio, 44*menu.ratio, 1.0, video.Color{R: 1, G: 1, B: 1, A: e.tagAlpha})
-				vid.DrawBorder(stack, float32(h)*e.yp-22*menu.ratio,
-					60*menu.ratio, 44*menu.ratio, 0.05/menu.ratio, video.Color{R: 0, G: 0, B: 0, A: e.tagAlpha / 4})
-				stack += 60 * menu.ratio
+				if _, ok := menu.icons[tag]; ok {
+					stack += 20
+					vid.DrawImage(
+						menu.icons[tag],
+						stack, float32(h)*e.yp-22*menu.ratio,
+						60*menu.ratio, 44*menu.ratio, 1.0, video.Color{R: 1, G: 1, B: 1, A: e.tagAlpha})
+					vid.DrawBorder(stack, float32(h)*e.yp-22*menu.ratio,
+						60*menu.ratio, 44*menu.ratio, 0.05/menu.ratio, video.Color{R: 0, G: 0, B: 0, A: e.tagAlpha / 4})
+					stack += 60 * menu.ratio
+				}
 			}
 		}
 	}

--- a/menu/thumbnail.go
+++ b/menu/thumbnail.go
@@ -63,8 +63,8 @@ func scrubIllegalChars(str string) string {
 // Draws a thumbnail in the playlist scene.
 func drawThumbnail(list *entry, i int, system, gameName string, x, y, w, h, scale float32, color video.Color) {
 	folderPath := filepath.Join(settings.Current.ThumbnailsDirectory, system, "Named_Snaps")
-	path := filepath.Join(folderPath, gameName+".png")
 	legalName := scrubIllegalChars(gameName)
+	path := filepath.Join(folderPath, legalName+".png")
 	url := "http://thumbnails.libretro.com/" + system + "/Named_Snaps/" + legalName + ".png"
 
 	if list.children[i].thumbnail == 0 || list.children[i].thumbnail == menu.icons["img-dl"] {

--- a/playlists/playlists.go
+++ b/playlists/playlists.go
@@ -29,17 +29,35 @@ type Playlist []Game
 // Playlists is a map of playlists organized per system.
 var Playlists = map[string]Playlist{}
 
-// Load loops over lpl files in the playlists directory and loads them into
-// memory.
-func Load() {
+// Gets a list of full paths to playlists
+func getPaths() (paths []string) {
 	paths, err := filepath.Glob(settings.Current.PlaylistsDirectory + "/*.csv")
 	if err != nil {
 		log.Println(err)
-		return
 	}
+	return
+}
 
-	Playlists = map[string]Playlist{}
-	for _, path := range paths {
+// Update older versions of playlists
+func Update() {
+	for _, fp := range getPaths() {
+
+		// Renames FB Alpha playlist to FBNeo playlist
+		if filepath.Base(fp) == "FB Alpha - Arcade Games.csv" {
+			newPath := filepath.Join(filepath.Dir(fp), "FBNeo - Arcade Games.csv")
+			if err := os.Rename(fp, newPath); err == nil {
+				log.Println("[INFO]: Renamed playlist:", filepath.Base(fp))
+			} else {
+				log.Println("Error renaming playlist:", err)
+			}
+		}
+	}
+}
+
+// Load loops over lpl files in the playlists directory and loads them into
+// memory.
+func Load() {
+	for _, path := range getPaths() {
 		path := path
 
 		file, err := os.Open(path)

--- a/playlists/playlists.go
+++ b/playlists/playlists.go
@@ -111,7 +111,7 @@ func ShortName(in string) string {
 		"Bandai - WonderSwan":                            "WonderSwan",
 		"Coleco - ColecoVision":                          "ColecoVision",
 		"Commodore - 64":                                 "Commodore 64",
-		"FB Alpha - Arcade Games":                        "Arcade (FB Alpha)",
+		"FBNeo - Arcade Games":                           "Arcade (FBNeo)",
 		"GCE - Vectrex":                                  "Vectrex",
 		"Magnavox - Odyssey2":                            "Magnavox Odyssey²",
 		"Microsoft - MSX":                                "MSX",

--- a/playlists/playlists_test.go
+++ b/playlists/playlists_test.go
@@ -106,9 +106,9 @@ func TestShortName(t *testing.T) {
 		{
 			name: "Should specify vendor as additional information",
 			args: args{
-				in: "FB Alpha - Arcade Games",
+				in: "FBNeo - Arcade Games",
 			},
-			want: "Arcade (FB Alpha)",
+			want: "Arcade (FBNeo)",
 		},
 		{
 			name: "Should remove vendor and alternative name",

--- a/settings/defaults.go
+++ b/settings/defaults.go
@@ -31,7 +31,7 @@ func defaultSettings() Settings {
 			"Cave Story":                                     "nxengine_libretro",
 			"ChaiLove":                                       "chailove_libretro",
 			"Coleco - ColecoVision":                          "bluemsx_libretro",
-			"FB Alpha - Arcade Games":                        "fbneo_libretro",
+			"FBNeo - Arcade Games":                           "fbneo_libretro",
 			"GCE - Vectrex":                                  "vecx_libretro",
 			"Magnavox - Odyssey2":                            "o2em_libretro",
 			"Microsoft - MSX":                                "bluemsx_libretro",


### PR DESCRIPTION
Hello... This fixes 3 issues with images in playlists I found trying out ludo.

1. Unable to find thumbs with special characters in ./ludo/thumbnails/ directory

2. Unable to download Arcade thumbs because server returns 404 on 'FB Alpha' urls.

3. Showing black image for unknown game tags.

Note: Requires updates to database and assets repos changing names from 'FB Alpha' to 'FBNeo' ~~and will break user playlist (must rename existing 'FB Alpha' playlist)~~.