### PR TITLE
OpenGL core support improvements

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -189,7 +189,7 @@ func LoadGame(gamePath string) error {
 	ntf.Display(ntf.Info, "Press P to toggle the menu", ntf.Medium)
 
 	if state.Global.Core.HWRenderCallback != nil {
-		vid.InitFramebuffer(vid.Geom.BaseWidth, vid.Geom.BaseHeight)
+		vid.InitFramebuffer()
 		state.Global.Core.HWRenderCallback.ContextReset()
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7
 	github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1
+	github.com/go-gl/mathgl v0.0.0-20190713194549-592312d8590a
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/kivutar/glfont v0.0.0-20191031044325-c308d6367f39
 	github.com/lucasb-eyer/go-colorful v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7 h1:SCYMcCJ89LjRGwEa0tRluNRiMjZHalQZrVrvTbPh+qw=
 github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7/go.mod h1:482civXOzJJCPzJ4ZOX/pwvXBWSnzD4OKMdH4ClKGbk=
+github.com/go-gl/mathgl v0.0.0-20190713194549-592312d8590a h1:yoAEv7yeWqfL/l9A/J5QOndXIJCldv+uuQB1DSNQbS0=
+github.com/go-gl/mathgl v0.0.0-20190713194549-592312d8590a/go.mod h1:yhpkQzEiH9yPyxDUGzkmgScbaBVlhC06qodikEM0ZwQ=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/kivutar/glfont v0.0.0-20191031044325-c308d6367f39 h1:s55p6dLs5iEBt1eqUYNTv7OfnBPubli1YnTTp/H3Ov8=
@@ -41,6 +43,7 @@ golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067 h1:KYGJGHOQy8oSi1fDlSpcZF0+juKwk/hEMv5SiwHogR0=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
+golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/mobile v0.0.0-20190607214518-6fa95d984e88 h1:H6DkDrMSuEE2MQR7DgGwkzbXSY1lvMpEN5MDE1bo/5U=

--- a/libretro/libretro.go
+++ b/libretro/libretro.go
@@ -571,7 +571,7 @@ func coreAudioSampleBatch(buf unsafe.Pointer, frames C.size_t) C.size_t {
 	if audioSampleBatch == nil {
 		return 0
 	}
-	return C.size_t(audioSampleBatch(C.GoBytes(buf, C.int(4*int(frames))), int32(frames)))
+	return C.size_t(audioSampleBatch(C.GoBytes(buf, C.int(4*int(frames))), int32(frames))) / 4
 }
 
 //export coreLog

--- a/libretro/libretro.go
+++ b/libretro/libretro.go
@@ -63,6 +63,8 @@ type GameGeometry struct {
 	AspectRatio float64
 	BaseWidth   int
 	BaseHeight  int
+	MaxWidth    int
+	MaxHeight   int
 }
 
 // GameInfo stores information about a ROM
@@ -414,6 +416,8 @@ func (core *Core) GetSystemAVInfo() SystemAVInfo {
 			AspectRatio: float64(avi.geometry.aspect_ratio),
 			BaseWidth:   int(avi.geometry.base_width),
 			BaseHeight:  int(avi.geometry.base_height),
+			MaxWidth:    int(avi.geometry.max_width),
+			MaxHeight:   int(avi.geometry.max_height),
 		},
 		Timing: SystemTiming{
 			FPS:        float64(avi.timing.fps),
@@ -643,6 +647,8 @@ func GetGeometry(data unsafe.Pointer) GameGeometry {
 		AspectRatio: float64(geometry.aspect_ratio),
 		BaseWidth:   int(geometry.base_width),
 		BaseHeight:  int(geometry.base_height),
+		MaxWidth:    int(geometry.max_width),
+		MaxHeight:   int(geometry.max_height),
 	}
 }
 
@@ -655,6 +661,8 @@ func GetSystemAVInfo(data unsafe.Pointer) SystemAVInfo {
 			AspectRatio: float64(avi.geometry.aspect_ratio),
 			BaseWidth:   int(avi.geometry.base_width),
 			BaseHeight:  int(avi.geometry.base_height),
+			MaxWidth:    int(avi.geometry.max_width),
+			MaxHeight:   int(avi.geometry.max_height),
 		},
 		Timing: SystemTiming{
 			FPS:        float64(avi.timing.fps),

--- a/video/default_vert_shader.go
+++ b/video/default_vert_shader.go
@@ -19,8 +19,10 @@ COMPAT_ATTRIBUTE vec2 vertTexCoord;
 
 COMPAT_VARYING vec2 fragTexCoord;
 
+uniform mat4 MVP;
+
 void main() {
   fragTexCoord = vertTexCoord;
-  gl_Position = vec4(vert, 0.0, 1.0);
+  gl_Position = vec4(vert, 0.0, 1.0) * MVP;
 }
 ` + "\x00"

--- a/video/shader_utils.go
+++ b/video/shader_utils.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/go-gl/gl/all-core/gl"
+	"github.com/go-gl/mathgl/mgl32"
 )
 
 func newProgram(GLSLVersion uint, vertexShaderSource, fragmentShaderSource string) (uint32, error) {
@@ -41,6 +42,17 @@ func newProgram(GLSLVersion uint, vertexShaderSource, fragmentShaderSource strin
 
 	gl.DeleteShader(vertexShader)
 	gl.DeleteShader(fragmentShader)
+
+	// Only the core rendering code uses MVPs so we set it to identity
+	// to avoid issues with other parts of the program
+	gl.UseProgram(program)
+	mvp := gl.GetUniformLocation(program, gl.Str("MVP\x00"))
+
+	if mvp != -1 {
+		IdentityMatrix := mgl32.Ident4()
+		gl.UniformMatrix4fv(mvp, 1, false, &IdentityMatrix[0])
+	}
+	gl.UseProgram(0)
 
 	return program, nil
 }

--- a/video/video.go
+++ b/video/video.go
@@ -74,6 +74,14 @@ func Init(fullscreen bool) *Video {
 // Reconfigure destroys and recreates the window with new attributes
 func (video *Video) Reconfigure(fullscreen bool) {
 	if video.Window != nil {
+		// This is the expected frontend behavior and Flycast requires this
+		// for fullscreen toggling to work, but ppsspp breaks. OTOH, ppsspp
+		// breaks in those situations even if we don't call context_destroy
+		// so ignore it.
+		hw := state.Global.Core.HWRenderCallback
+		if state.Global.CoreRunning && hw != nil && hw.ContextDestroy != nil {
+			state.Global.Core.HWRenderCallback.ContextDestroy()
+		}
 		video.Window.Destroy()
 	}
 	video.Configure(fullscreen)


### PR DESCRIPTION
This pull request does the following:

- Fixes OpenGL core support:
  * Switches to/from the appropriate framebuffers when rendering the core and or menu
  * Renders the core video data in OpenGL mode even if pitch is zero (this might need to be improved in the future)
  * Correctly handles the core's expected video origin
  * Notifies the core when the context gets destroyed
- Fixes the return value of the sample batch callback:
  * This prevents a crash (heap overflow IIRC) in Mupen64 cores and any other that actually cared for the return value.
- Implements the required clipping in video data:
  * Implements the core expectation that the framebuffer as big as `max_width`/`max_height`
  * Fixes cores that output more pixels than required for the specified geometry (such as bsnes/higan in accuracy mode outputting with doubled horizontal resolution)

Some test results:

- Flycast runs fine
- PPSSPP runs fine but is unstable when the OpenGL context changes. This is a core problem as [Autechre and m4xwt](https://imgur.com/a/oyHZxSG) told me.
- Mupen64 runs on Windows, but breaks when toggling fullscreen (see libco notes bellow).

The big bad problem called libco
===

When I was testing ludo I found out a really nasty problem involving running cores that use libco. Most, if not all, of these cores use libco to "unwrap" the callstack so that the program can run frame-by-frame. This is fine in RetroArch and other frontends either because 1. they don't use cooperative threads in the frontend or 2. they don't use golang.

These cores switch back and forth from the deep callstacks sometimes millions of times per frame (such as in bsnes/higan accuracy) and this can happen any time. The problem is that whenever the core does that it takes a snapshot of the stack for when it switches back and no one can predict what the internal control flow will look like, so, sometimes, callbacks such as `video_refresh` will be called with stacks from the "past" (e.g. from previous frames or from when `retro_init` was called) and this will make the go runtime go nuts.

[This minimal software-only core](https://github.com/libretro/ludo/files/4167952/test_libco.zip) is enough to break ludo on Linux just because it calls `video_refresh` from a different libco thread that was initialized in `retro_init`. I pointed out that it breaks on Linux because the situation changes from OS to OS. For instance, the mupen cores render a single frame then crash on Linux but will run just fine on Windows as long as you don't call any of the OpenGL callbacks (like when toggling fullscreen), because these will switch to other libco threads and mess up the golang stack.