### PR TITLE
Fix sharp-bilinear and zfast-crt filters

### DIFF
--- a/video/video.go
+++ b/video/video.go
@@ -523,7 +523,7 @@ func (video *Video) Refresh(data unsafe.Pointer, width int32, height int32, pitc
 	gl.BindTexture(gl.TEXTURE_2D, video.texID)
 	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, int32(video.Geom.MaxWidth), int32(video.Geom.MaxHeight), 0, video.pixType, video.pixFmt, nil)
 
-	gl.Uniform2f(gl.GetUniformLocation(video.program, gl.Str("TextureSize\x00")), float32(width), float32(height))
+	gl.Uniform2f(gl.GetUniformLocation(video.program, gl.Str("TextureSize\x00")), float32(video.Geom.MaxWidth), float32(video.Geom.MaxHeight))
 	gl.Uniform2f(gl.GetUniformLocation(video.program, gl.Str("InputSize\x00")), float32(width), float32(height))
 
 	gl.UseProgram(0)


### PR DESCRIPTION
TextureSize uniform was receiving the input size instead of the actual texture
size.