### PR TITLE
audio: fix handling of Sample(l,r) 

### DIFF
--- a/audio/audio_test.go
+++ b/audio/audio_test.go
@@ -15,7 +15,8 @@ func Test_alUnqueueBuffers(t *testing.T) {
 
 func Test_Sample(t *testing.T) {
 	t.Run("Doesn't crash when called", func(t *testing.T) {
-		Sample(30000, 30000)
+		Sample(-30000, -30000)
+		Sample( 30000,  30000)
 	})
 }
 
@@ -49,7 +50,7 @@ func Test_fillInternalBuf(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := fillInternalBuf(tt.args.buf, tt.args.size); got != tt.want {
+			if got := fillInternalBuf(tt.args.buf[:tt.args.size]); got != tt.want {
 				t.Errorf("fillInternalBuf() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
It passed invalid sized data to the write buffer.

Resulting audio would have been corrupted, and probably it'd crash if mixing calls to SampleBatch() and Sample(). 

(probably a test should be added for this case...)