### PR TITLE
Add support for iBuffalo classic controller and 8Bitdo SF30/SN30

### DIFF
--- a/input/binds_linux.go
+++ b/input/binds_linux.go
@@ -12,7 +12,7 @@ var joyBinds = map[string]joybinds{
 	"SHANWAN PS3 GamePad":                                ds3JoyBinds,
 	"8Bitdo NES30 Pro   8Bitdo NES30 Pro":                nes30proJoyBinds,
 	"8Bitdo SN30 Pro":                                    snsf30proJoyBinds,
-	"8Bitdo SF30 Pro   8Bitdo SN30 Pro":                  snsf30proJoyBinds,
+	"8Bitdo SF30 Pro   8Bitdo SN30 Pro":                  snsf30proWiredJoyBinds,
 	"SFC30              SFC30 Joystick":                  sfc30JoyBinds,
 	"SNES30             SNES30 Joy":                      sfc30JoyBinds,
 	"USB,2-axis 8-button gamepad":                        iBuffaloClassicBinds,
@@ -122,7 +122,7 @@ var nes30proJoyBinds = joybinds{
 	bind{btn, 15, 0, 0}: libretro.DeviceIDJoypadUp,
 }
 
-// Joypad bindings for the 8Bitdo SF30 Pro and SN30 Pro GamePad on Linux
+// Joypad bindings for the 8Bitdo SF30 Pro and SN30 Pro GamePad (Wireless) on Linux
 var snsf30proJoyBinds = joybinds{
 	bind{btn, 0, 0, 0}:  libretro.DeviceIDJoypadA,
 	bind{btn, 1, 0, 0}:  libretro.DeviceIDJoypadB,
@@ -140,6 +140,27 @@ var snsf30proJoyBinds = joybinds{
 	bind{btn, 17, 0, 0}: libretro.DeviceIDJoypadRight,
 	bind{btn, 18, 0, 0}: libretro.DeviceIDJoypadDown,
 	bind{btn, 19, 0, 0}: libretro.DeviceIDJoypadLeft,
+}
+
+// Joypad bindings for the 8Bitdo SF30 Pro and SN30 Pro GamePad (Wired) on Linux
+var snsf30proWiredJoyBinds = joybinds{
+	bind{btn, 0, 0, 0}:  libretro.DeviceIDJoypadA,
+	bind{btn, 1, 0, 0}:  libretro.DeviceIDJoypadB,
+	bind{btn, 3, 0, 0}:  libretro.DeviceIDJoypadX,
+	bind{btn, 4, 0, 0}:  libretro.DeviceIDJoypadY,
+	bind{btn, 6, 0, 0}:  libretro.DeviceIDJoypadL,
+	bind{btn, 7, 0, 0}:  libretro.DeviceIDJoypadR,
+	bind{btn, 8, 0, 0}:  libretro.DeviceIDJoypadL2,
+	bind{btn, 9, 0, 0}:  libretro.DeviceIDJoypadR2,
+	bind{btn, 10, 0, 0}: libretro.DeviceIDJoypadSelect,
+	bind{btn, 11, 0, 0}: libretro.DeviceIDJoypadStart,
+	bind{btn, 13, 0, 0}: libretro.DeviceIDJoypadL3,
+	bind{btn, 14, 0, 0}: libretro.DeviceIDJoypadR3,
+
+	bind{btn, 17, 0, 0}: libretro.DeviceIDJoypadDown,
+	bind{btn, 18, 0, 0}: libretro.DeviceIDJoypadLeft,
+	bind{btn, 16, 0, 0}: libretro.DeviceIDJoypadRight,
+	bind{btn, 15, 0, 0}: libretro.DeviceIDJoypadUp,
 }
 
 // Joypad bindings for the 8BITDO SFC30 pad (Wired) on Linux
@@ -173,4 +194,3 @@ var iBuffaloClassicBinds = joybinds{
 	bind{axis, 0, 1, 0.5}:   libretro.DeviceIDJoypadRight,
 	bind{axis, 1, 1, 0.5}:   libretro.DeviceIDJoypadDown,
 }
-

--- a/input/binds_linux.go
+++ b/input/binds_linux.go
@@ -11,11 +11,14 @@ var joyBinds = map[string]joybinds{
 	"Sony PLAYSTATION(R)3 Controller":                    ds3JoyBinds,
 	"SHANWAN PS3 GamePad":                                ds3JoyBinds,
 	"8Bitdo NES30 Pro   8Bitdo NES30 Pro":                nes30proJoyBinds,
+	"8Bitdo SN30 Pro":                                    snsf30proJoyBinds,
+	"8Bitdo SF30 Pro   8Bitdo SN30 Pro":                  snsf30proJoyBinds,
 	"SFC30              SFC30 Joystick":                  sfc30JoyBinds,
-	"SNES30             SNES30 Joy    ":                  sfc30JoyBinds,
+	"SNES30             SNES30 Joy":                      sfc30JoyBinds,
+	"USB,2-axis 8-button gamepad":                        iBuffaloClassicBinds,
 }
 
-// Joypad bindings fox Xbox360 pad on Linux
+// Joypad bindings for Xbox360 pad on Linux
 var xbox360JoyBinds = joybinds{
 	bind{btn, 0, 0, 0}:    libretro.DeviceIDJoypadB,
 	bind{btn, 1, 0, 0}:    libretro.DeviceIDJoypadA,
@@ -36,7 +39,7 @@ var xbox360JoyBinds = joybinds{
 	bind{axis, 5, 1, 0.5}: libretro.DeviceIDJoypadR2,
 }
 
-// Joypad bindings fox Xbox One pad on Linux
+// Joypad bindings for Xbox One pad on Linux
 var xboxOneJoyBinds = joybinds{
 	bind{btn, 0, 0, 0}:    libretro.DeviceIDJoypadB,
 	bind{btn, 1, 0, 0}:    libretro.DeviceIDJoypadA,
@@ -57,7 +60,7 @@ var xboxOneJoyBinds = joybinds{
 	bind{axis, 5, 1, 0.5}: libretro.DeviceIDJoypadR2,
 }
 
-// Joypad bindings fox DualShock 4 pad on Linux
+// Joypad bindings for DualShock 4 pad on Linux
 var ds4JoyBinds = joybinds{
 	bind{btn, 0, 0, 0}:  libretro.DeviceIDJoypadB,
 	bind{btn, 1, 0, 0}:  libretro.DeviceIDJoypadA,
@@ -78,7 +81,7 @@ var ds4JoyBinds = joybinds{
 	bind{btn, 15, 0, 0}: libretro.DeviceIDJoypadDown,
 }
 
-// Joypad bindings fox DualShock 3 pad on Linux
+// Joypad bindings for DualShock 3 pad on Linux
 var ds3JoyBinds = joybinds{
 	bind{btn, 0, 0, 0}:  libretro.DeviceIDJoypadB,
 	bind{btn, 1, 0, 0}:  libretro.DeviceIDJoypadA,
@@ -99,7 +102,7 @@ var ds3JoyBinds = joybinds{
 	bind{btn, 16, 0, 0}: libretro.DeviceIDJoypadRight,
 }
 
-// Joypad bindings fox the 8BITDO NES30 PRO GamePad (Wired) on Linux
+// Joypad bindings for the 8BITDO NES30 PRO GamePad (Wired) on Linux
 var nes30proJoyBinds = joybinds{
 	bind{btn, 0, 0, 0}:  libretro.DeviceIDJoypadA,
 	bind{btn, 1, 0, 0}:  libretro.DeviceIDJoypadB,
@@ -119,7 +122,27 @@ var nes30proJoyBinds = joybinds{
 	bind{btn, 15, 0, 0}: libretro.DeviceIDJoypadUp,
 }
 
-// Joypad bindings fox the 8BITDO SFC30 pad (Wired) on Linux
+// Joypad bindings for the 8Bitdo SF30 Pro and SN30 Pro GamePad on Linux
+var snsf30proJoyBinds = joybinds{
+	bind{btn, 0, 0, 0}:  libretro.DeviceIDJoypadA,
+	bind{btn, 1, 0, 0}:  libretro.DeviceIDJoypadB,
+	bind{btn, 3, 0, 0}:  libretro.DeviceIDJoypadX,
+	bind{btn, 4, 0, 0}:  libretro.DeviceIDJoypadY,
+	bind{btn, 6, 0, 0}:  libretro.DeviceIDJoypadL,
+	bind{btn, 7, 0, 0}:  libretro.DeviceIDJoypadR,
+	bind{btn, 8, 0, 0}:  libretro.DeviceIDJoypadL2,
+	bind{btn, 9, 0, 0}:  libretro.DeviceIDJoypadR2,
+	bind{btn, 10, 0, 0}: libretro.DeviceIDJoypadSelect,
+	bind{btn, 11, 0, 0}: libretro.DeviceIDJoypadStart,
+	bind{btn, 13, 0, 0}: libretro.DeviceIDJoypadL3,
+	bind{btn, 14, 0, 0}: libretro.DeviceIDJoypadR3,
+	bind{btn, 16, 0, 0}: libretro.DeviceIDJoypadUp,
+	bind{btn, 17, 0, 0}: libretro.DeviceIDJoypadRight,
+	bind{btn, 18, 0, 0}: libretro.DeviceIDJoypadDown,
+	bind{btn, 19, 0, 0}: libretro.DeviceIDJoypadLeft,
+}
+
+// Joypad bindings for the 8BITDO SFC30 pad (Wired) on Linux
 var sfc30JoyBinds = joybinds{
 	bind{btn, 0, 0, 0}:      libretro.DeviceIDJoypadA,
 	bind{btn, 1, 0, 0}:      libretro.DeviceIDJoypadB,
@@ -134,3 +157,20 @@ var sfc30JoyBinds = joybinds{
 	bind{axis, 0, 1, 0.5}:   libretro.DeviceIDJoypadRight,
 	bind{axis, 1, 1, 0.5}:   libretro.DeviceIDJoypadDown,
 }
+
+// Joypad bindings for the iBuffalo Classic USB Gamepad (Wired) on Linux
+var iBuffaloClassicBinds = joybinds{
+	bind{btn, 0, 0, 0}:      libretro.DeviceIDJoypadA,
+	bind{btn, 1, 0, 0}:      libretro.DeviceIDJoypadB,
+	bind{btn, 2, 0, 0}:      libretro.DeviceIDJoypadX,
+	bind{btn, 3, 0, 0}:      libretro.DeviceIDJoypadY,
+	bind{btn, 4, 0, 0}:      libretro.DeviceIDJoypadL,
+	bind{btn, 5, 0, 0}:      libretro.DeviceIDJoypadR,
+	bind{btn, 6, 0, 0}:      libretro.DeviceIDJoypadSelect,
+	bind{btn, 7, 0, 0}:      libretro.DeviceIDJoypadStart,
+	bind{axis, 0, -1, -0.5}: libretro.DeviceIDJoypadLeft,
+	bind{axis, 1, -1, -0.5}: libretro.DeviceIDJoypadUp,
+	bind{axis, 0, 1, 0.5}:   libretro.DeviceIDJoypadRight,
+	bind{axis, 1, 1, 0.5}:   libretro.DeviceIDJoypadDown,
+}
+

--- a/input/input.go
+++ b/input/input.go
@@ -9,6 +9,7 @@ import (
 	ntf "github.com/libretro/ludo/notifications"
 	"github.com/libretro/ludo/settings"
 	"github.com/libretro/ludo/video"
+	"strings"
 )
 
 // MaxPlayers is the maximum number of players to poll input for
@@ -60,10 +61,11 @@ const (
 func joystickCallback(joy glfw.Joystick, event glfw.PeripheralEvent) {
 	switch event {
 	case glfw.Connected:
+		name := strings.TrimSpace(glfw.Joystick.GetName(joy))
 		if HasBinding(joy) {
-			ntf.DisplayAndLog(ntf.Info, "Input", "Joystick #%d plugged: %s.", joy, glfw.Joystick.GetName(joy))
+			ntf.DisplayAndLog(ntf.Info, "Input", "Joystick #%d plugged: %s.", joy, name)
 		} else {
-			ntf.DisplayAndLog(ntf.Warning, "Input", "Joystick #%d plugged: %s but not configured.", joy, glfw.Joystick.GetName(joy))
+			ntf.DisplayAndLog(ntf.Warning, "Input", "Joystick #%d plugged: %s but not configured.", joy, name)
 		}
 	case glfw.Disconnected:
 		ntf.DisplayAndLog(ntf.Info, "Input", "Joystick #%d unplugged.", joy)
@@ -89,7 +91,7 @@ func pollJoypads(state States, analogState AnalogStates) (States, AnalogStates) 
 	for p := range state {
 		buttonState := glfw.Joystick.GetButtons(glfw.Joystick(p))
 		axisState := glfw.Joystick.GetAxes(glfw.Joystick(p))
-		name := glfw.Joystick.GetName(glfw.Joystick(p))
+		name := strings.TrimSpace(glfw.Joystick.GetName(glfw.Joystick(p)))
 		jb := joyBinds[name]
 		if len(buttonState) > 0 {
 			for k, v := range jb {
@@ -202,7 +204,7 @@ func State(port uint, device uint32, index uint, id uint) int16 {
 
 // HasBinding returns true if the joystick has an autoconfig binding
 func HasBinding(joy glfw.Joystick) bool {
-	name := glfw.Joystick.GetName(joy)
+	name := strings.TrimSpace(glfw.Joystick.GetName(joy))
 	_, ok := joyBinds[name]
 	return ok
 }


### PR DESCRIPTION
Hey,

This adds config for a couple of snes controllers I have.

The iBuffalo classic controller comes up under the name "USB,2-axis 8-button gamepad  " with some extra spaces at the end, which is why I thought it might be a good idea to trim white space from `glfw.Joystick.GetName(joy)`, not sure if this could have unintended side effects on other controllers, but I don't think it should.

Also fixes what I suppose is a typo in `input/binds_linux.go` (fox -> for) :)