### PR TITLE
ludo --help behaviour

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"runtime"
@@ -79,7 +80,18 @@ func main() {
 		log.Println("[Settings]: Using default settings")
 	}
 
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	// ExitOnError causes flags to quit after displaying help.
+	// (--help counts as an error)
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	// customize help message
+	flag.CommandLine.Usage = func() {
+		fmt.Printf("Usage: %s [OPTIONS] [content]\n", os.Args[0])
+		fmt.Printf("Options:\n")
+		flag.PrintDefaults()
+	}
+
+	// set arguments
 	flag.StringVar(&state.CorePath, "L", "", "Path to the libretro core")
 	flag.BoolVar(&state.Verbose, "v", false, "Verbose logs")
 	flag.BoolVar(&state.LudOS, "ludos", false, "Expose the features related to LudOS")


### PR DESCRIPTION
## Problem

`ludo --help` / `-h` displays help but has these unexpected behaviours:
 - gui launches (normally, `--help` / `-h` suppresses gui and other behaviour in most programs)
 - help does not explain that content can be provided as a positional argument.

## Changes

- shows that content is an optional argument
- does not launch ludo if `--help` / `-h` provided