### PR TITLE
Separation of libretro Core from os-specific dlopen/LoadLibrary interface

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -36,7 +36,7 @@ func Init(v *video.Video) {
 
 // Load loads a libretro core
 func Load(sofile string) error {
-	// In case the a core is already loaded, we need to close it properly
+	// In case a core is already loaded, we need to close it properly
 	// before loading the new core
 	Unload()
 

--- a/core/environment.go
+++ b/core/environment.go
@@ -166,6 +166,8 @@ func environment(cmd uint32, data unsafe.Pointer) bool {
 	case libretro.EnvironmentGetVariableUpdate:
 		libretro.SetBool(data, Options.Updated)
 		Options.Updated = false
+	case libretro.EnvironmentSetMemoryMaps:
+		state.Core.MemoryMap = libretro.GetMemoryMap(data)
 	case libretro.EnvironmentSetGeometry:
 		vid.Geom = libretro.GetGeometry(data)
 	case libretro.EnvironmentSetSystemAVInfo:

--- a/libretro/cfuncs.go
+++ b/libretro/cfuncs.go
@@ -38,8 +38,8 @@ void bridge_retro_get_system_av_info(void *f, struct retro_system_av_info *si) {
   return ((void (*)(struct retro_system_av_info *))f)(si);
 }
 
-bool bridge_retro_set_environment(void *f, void *callback) {
-	return ((bool (*)(retro_environment_t))f)((retro_environment_t)callback);
+void bridge_retro_set_environment(void *f, void *callback) {
+	return ((void (*)(retro_environment_t))f)((retro_environment_t)callback);
 }
 
 void bridge_retro_set_video_refresh(void *f, void *callback) {

--- a/libretro/libretro.go
+++ b/libretro/libretro.go
@@ -480,7 +480,7 @@ func (core *Core) APIVersion() uint {
 // Deinit takes care of the library global deinitialization
 func (core *Core) Deinit() {
 	C.bridge_retro_deinit(core.symRetroDeinit)
-	//DlClose(core.handle) // this causes an error.
+	DlClose(core.handle)
 	core.MemoryMap = nil
 	environment = nil
 	videoRefresh = nil
@@ -490,7 +490,6 @@ func (core *Core) Deinit() {
 	inputState = nil
 	log = nil
 	getTimeUsec = nil
-	core.DlClose()
 }
 
 // Run runs the game for one video frame.
@@ -800,11 +799,11 @@ func GetCoreOptionsIntl(data unsafe.Pointer) []CoreOptionDefinition {
 // GetMemoryMap is an environment callback helper that returns the list of
 // memory regions EnvironmentSetMemoryMap.
 func GetMemoryMap(data unsafe.Pointer) []MemoryDescriptor {
-	c_memmap := (*C.struct_retro_memory_map)(data)
-	descriptors := make([]MemoryDescriptor, int(c_memmap.num_descriptors))
+	cMemmap := (*C.struct_retro_memory_map)(data)
+	descriptors := make([]MemoryDescriptor, int(cMemmap.num_descriptors))
 	for i := 0; i < len(descriptors); i++ {
-		c_descriptor := unsafe.Pointer(uintptr(unsafe.Pointer(c_memmap.descriptors)) + uintptr(i)*unsafe.Sizeof(*c_memmap.descriptors))
-		d := *(*C.struct_retro_memory_descriptor)(c_descriptor)
+		cDescriptor := unsafe.Pointer(uintptr(unsafe.Pointer(cMemmap.descriptors)) + uintptr(i)*unsafe.Sizeof(*cMemmap.descriptors))
+		d := *(*C.struct_retro_memory_descriptor)(cDescriptor)
 
 		descriptors[i] = MemoryDescriptor{
 			Flags:      uint64(d.flags),

--- a/libretro/libretro.go
+++ b/libretro/libretro.go
@@ -480,7 +480,7 @@ func (core *Core) APIVersion() uint {
 // Deinit takes care of the library global deinitialization
 func (core *Core) Deinit() {
 	C.bridge_retro_deinit(core.symRetroDeinit)
-	DlClose(core.handle)
+	//DlClose(core.handle) // this causes an error.
 	core.MemoryMap = nil
 	environment = nil
 	videoRefresh = nil

--- a/libretro/libretro.go
+++ b/libretro/libretro.go
@@ -18,7 +18,7 @@ void bridge_retro_deinit(void *f);
 unsigned bridge_retro_api_version(void *f);
 void bridge_retro_get_system_info(void *f, struct retro_system_info *si);
 void bridge_retro_get_system_av_info(void *f, struct retro_system_av_info *si);
-bool bridge_retro_set_environment(void *f, void *callback);
+void bridge_retro_set_environment(void *f, void *callback);
 void bridge_retro_set_video_refresh(void *f, void *callback);
 void bridge_retro_set_controller_port_device(void *f, unsigned port, unsigned device);
 void bridge_retro_set_input_poll(void *f, void *callback);
@@ -429,27 +429,27 @@ func Load(sofile string) (*Core, error) {
 		return nil, err
 	}
 
-	core.symRetroInit = core.DlSym("retro_init")
-	core.symRetroDeinit = core.DlSym("retro_deinit")
-	core.symRetroAPIVersion = core.DlSym("retro_api_version")
-	core.symRetroGetSystemInfo = core.DlSym("retro_get_system_info")
-	core.symRetroGetSystemAVInfo = core.DlSym("retro_get_system_av_info")
-	core.symRetroSetEnvironment = core.DlSym("retro_set_environment")
-	core.symRetroSetVideoRefresh = core.DlSym("retro_set_video_refresh")
-	core.symRetroSetControllerPortDevice = core.DlSym("retro_set_controller_port_device")
-	core.symRetroSetInputPoll = core.DlSym("retro_set_input_poll")
-	core.symRetroSetInputState = core.DlSym("retro_set_input_state")
-	core.symRetroSetAudioSample = core.DlSym("retro_set_audio_sample")
-	core.symRetroSetAudioSampleBatch = core.DlSym("retro_set_audio_sample_batch")
-	core.symRetroRun = core.DlSym("retro_run")
-	core.symRetroReset = core.DlSym("retro_reset")
-	core.symRetroLoadGame = core.DlSym("retro_load_game")
-	core.symRetroUnloadGame = core.DlSym("retro_unload_game")
-	core.symRetroSerializeSize = core.DlSym("retro_serialize_size")
-	core.symRetroSerialize = core.DlSym("retro_serialize")
-	core.symRetroUnserialize = core.DlSym("retro_unserialize")
-	core.symRetroGetMemorySize = core.DlSym("retro_get_memory_size")
-	core.symRetroGetMemoryData = core.DlSym("retro_get_memory_data")
+	core.symRetroInit = DlSym(core.handle, "retro_init")
+	core.symRetroDeinit = DlSym(core.handle, "retro_deinit")
+	core.symRetroAPIVersion = DlSym(core.handle, "retro_api_version")
+	core.symRetroGetSystemInfo = DlSym(core.handle, "retro_get_system_info")
+	core.symRetroGetSystemAVInfo = DlSym(core.handle, "retro_get_system_av_info")
+	core.symRetroSetEnvironment = DlSym(core.handle, "retro_set_environment")
+	core.symRetroSetVideoRefresh = DlSym(core.handle, "retro_set_video_refresh")
+	core.symRetroSetControllerPortDevice = DlSym(core.handle, "retro_set_controller_port_device")
+	core.symRetroSetInputPoll = DlSym(core.handle, "retro_set_input_poll")
+	core.symRetroSetInputState = DlSym(core.handle, "retro_set_input_state")
+	core.symRetroSetAudioSample = DlSym(core.handle, "retro_set_audio_sample")
+	core.symRetroSetAudioSampleBatch = DlSym(core.handle, "retro_set_audio_sample_batch")
+	core.symRetroRun = DlSym(core.handle, "retro_run")
+	core.symRetroReset = DlSym(core.handle, "retro_reset")
+	core.symRetroLoadGame = DlSym(core.handle, "retro_load_game")
+	core.symRetroUnloadGame = DlSym(core.handle, "retro_unload_game")
+	core.symRetroSerializeSize = DlSym(core.handle, "retro_serialize_size")
+	core.symRetroSerialize = DlSym(core.handle, "retro_serialize")
+	core.symRetroUnserialize = DlSym(core.handle, "retro_unserialize")
+	core.symRetroGetMemorySize = DlSym(core.handle, "retro_get_memory_size")
+	core.symRetroGetMemoryData = DlSym(core.handle, "retro_get_memory_data")
 
 	return &core, nil
 }
@@ -468,6 +468,7 @@ func (core *Core) APIVersion() uint {
 // Deinit takes care of the library global deinitialization
 func (core *Core) Deinit() {
 	C.bridge_retro_deinit(core.symRetroDeinit)
+	DlClose(core.handle)
 	environment = nil
 	videoRefresh = nil
 	audioSample = nil

--- a/libretro/libretro_core.go
+++ b/libretro/libretro_core.go
@@ -31,4 +31,6 @@ type Core struct {
 	AudioCallback       *AudioCallback
 	FrameTimeCallback   *FrameTimeCallback
 	DiskControlCallback *DiskControlCallback
+
+	MemoryMap []MemoryDescriptor
 }

--- a/libretro/libretro_core.go
+++ b/libretro/libretro_core.go
@@ -1,0 +1,34 @@
+package libretro // Core is an instance of a dynamically loaded libretro core
+
+import "unsafe"
+
+// Core is an instance of a dynamically loaded libretro core
+type Core struct {
+	handle DlHandle
+
+	symRetroInit                    unsafe.Pointer
+	symRetroDeinit                  unsafe.Pointer
+	symRetroAPIVersion              unsafe.Pointer
+	symRetroGetSystemInfo           unsafe.Pointer
+	symRetroGetSystemAVInfo         unsafe.Pointer
+	symRetroSetEnvironment          unsafe.Pointer
+	symRetroSetVideoRefresh         unsafe.Pointer
+	symRetroSetControllerPortDevice unsafe.Pointer
+	symRetroSetInputPoll            unsafe.Pointer
+	symRetroSetInputState           unsafe.Pointer
+	symRetroSetAudioSample          unsafe.Pointer
+	symRetroSetAudioSampleBatch     unsafe.Pointer
+	symRetroRun                     unsafe.Pointer
+	symRetroReset                   unsafe.Pointer
+	symRetroLoadGame                unsafe.Pointer
+	symRetroUnloadGame              unsafe.Pointer
+	symRetroSerializeSize           unsafe.Pointer
+	symRetroSerialize               unsafe.Pointer
+	symRetroUnserialize             unsafe.Pointer
+	symRetroGetMemorySize           unsafe.Pointer
+	symRetroGetMemoryData           unsafe.Pointer
+
+	AudioCallback       *AudioCallback
+	FrameTimeCallback   *FrameTimeCallback
+	DiskControlCallback *DiskControlCallback
+}

--- a/libretro/libretro_notwindows.go
+++ b/libretro/libretro_notwindows.go
@@ -14,44 +14,16 @@ import (
 */
 import "C"
 
-// Core is an instance of a dynalically loaded libretro core
-type Core struct {
-	handle unsafe.Pointer
-
-	symRetroInit                    unsafe.Pointer
-	symRetroDeinit                  unsafe.Pointer
-	symRetroAPIVersion              unsafe.Pointer
-	symRetroGetSystemInfo           unsafe.Pointer
-	symRetroGetSystemAVInfo         unsafe.Pointer
-	symRetroSetEnvironment          unsafe.Pointer
-	symRetroSetVideoRefresh         unsafe.Pointer
-	symRetroSetControllerPortDevice unsafe.Pointer
-	symRetroSetInputPoll            unsafe.Pointer
-	symRetroSetInputState           unsafe.Pointer
-	symRetroSetAudioSample          unsafe.Pointer
-	symRetroSetAudioSampleBatch     unsafe.Pointer
-	symRetroRun                     unsafe.Pointer
-	symRetroReset                   unsafe.Pointer
-	symRetroLoadGame                unsafe.Pointer
-	symRetroUnloadGame              unsafe.Pointer
-	symRetroSerializeSize           unsafe.Pointer
-	symRetroSerialize               unsafe.Pointer
-	symRetroUnserialize             unsafe.Pointer
-	symRetroGetMemorySize           unsafe.Pointer
-	symRetroGetMemoryData           unsafe.Pointer
-
-	AudioCallback       *AudioCallback
-	FrameTimeCallback   *FrameTimeCallback
-	DiskControlCallback *DiskControlCallback
-}
+// DlHandle is a handle to a dynamic library
+type DlHandle = unsafe.Pointer
 
 // DlSym loads a symbol from a dynamic library
-func (core *Core) DlSym(name string) unsafe.Pointer {
-	return C.dlsym(core.handle, C.CString(name))
+func DlSym(handle DlHandle, name string) unsafe.Pointer {
+	return C.dlsym(handle, C.CString(name))
 }
 
 // DlOpen opens a dynamic library
-func DlOpen(path string) (unsafe.Pointer, error) {
+func DlOpen(path string) (DlHandle, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 
@@ -64,8 +36,14 @@ func DlOpen(path string) (unsafe.Pointer, error) {
 	return h, nil
 }
 
-// DlClose closes a dynamic library
-func (core *Core) DlClose() {
-	C.dlclose(core.handle)
+func DlClose(handle DlHandle) error {
+	result := C.dlclose(handle)
+	if int(result) != 0 {
+		cerr := C.dlerror()
+		if cerr != nil {
+			err := C.GoString(cerr)
+			return errors.New(err)
+		}
+	}
+	return nil
 }
-

--- a/libretro/libretro_notwindows.go
+++ b/libretro/libretro_notwindows.go
@@ -36,6 +36,7 @@ func DlOpen(path string) (DlHandle, error) {
 	return h, nil
 }
 
+// DlClose closes a dynamic library
 func DlClose(handle DlHandle) error {
 	result := C.dlclose(handle)
 	if int(result) != 0 {

--- a/libretro/libretro_windows.go
+++ b/libretro/libretro_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package libretro
 
 import (
@@ -22,14 +19,7 @@ func DlOpen(path string) (DlHandle, error) {
 	return syscall.LoadDLL(path)
 }
 
-<<<<<<< HEAD
 // DlClose closes a dynamic library
-func (core *Core) DlClose() {
-	core.handle.Release()
-}
-
-=======
 func DlClose(handle DlHandle) error {
 	return handle.Release()
 }
->>>>>>> encapsulation of dl* calls apart from Core struct

--- a/libretro/libretro_windows.go
+++ b/libretro/libretro_windows.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 package libretro
 
 import (
@@ -5,50 +8,28 @@ import (
 	"unsafe"
 )
 
-// Core is an instance of a dynalically loaded libretro core
-type Core struct {
-	handle *syscall.DLL
-
-	symRetroInit                    unsafe.Pointer
-	symRetroDeinit                  unsafe.Pointer
-	symRetroAPIVersion              unsafe.Pointer
-	symRetroGetSystemInfo           unsafe.Pointer
-	symRetroGetSystemAVInfo         unsafe.Pointer
-	symRetroSetEnvironment          unsafe.Pointer
-	symRetroSetVideoRefresh         unsafe.Pointer
-	symRetroSetControllerPortDevice unsafe.Pointer
-	symRetroSetInputPoll            unsafe.Pointer
-	symRetroSetInputState           unsafe.Pointer
-	symRetroSetAudioSample          unsafe.Pointer
-	symRetroSetAudioSampleBatch     unsafe.Pointer
-	symRetroRun                     unsafe.Pointer
-	symRetroReset                   unsafe.Pointer
-	symRetroLoadGame                unsafe.Pointer
-	symRetroUnloadGame              unsafe.Pointer
-	symRetroSerializeSize           unsafe.Pointer
-	symRetroSerialize               unsafe.Pointer
-	symRetroUnserialize             unsafe.Pointer
-	symRetroGetMemorySize           unsafe.Pointer
-	symRetroGetMemoryData           unsafe.Pointer
-
-	AudioCallback       *AudioCallback
-	FrameTimeCallback   *FrameTimeCallback
-	DiskControlCallback *DiskControlCallback
-}
+// DlHandle is a handle to a dynamic library
+type DlHandle = *syscall.DLL
 
 // DlSym loads a symbol from a dynamic library
-func (core *Core) DlSym(name string) unsafe.Pointer {
-	proc := core.handle.MustFindProc(name)
+func DlSym(handle DlHandle, name string) unsafe.Pointer {
+	proc := handle.MustFindProc(name)
 	return unsafe.Pointer(proc.Addr())
 }
 
 // DlOpen opens a dynamic library
-func DlOpen(path string) (*syscall.DLL, error) {
+func DlOpen(path string) (DlHandle, error) {
 	return syscall.LoadDLL(path)
 }
 
+<<<<<<< HEAD
 // DlClose closes a dynamic library
 func (core *Core) DlClose() {
 	core.handle.Release()
 }
 
+=======
+func DlClose(handle DlHandle) error {
+	return handle.Release()
+}
+>>>>>>> encapsulation of dl* calls apart from Core struct


### PR DESCRIPTION
## Changes

- Previously, the entirety of the libretro.Core object definition was duplicated across a windows and nonwindows file. Now there is no duplication of code; Core is now defined in libretro_core.go
- Added support for libretro cores' ENVIRONMENT_SET_MEMORY_MAPS (not actually used for anything yet.)