### PR TITLE
[New Feature] Integer scaling

### DIFF
--- a/menu/scene_settings.go
+++ b/menu/scene_settings.go
@@ -168,6 +168,12 @@ var incrCallbacks = map[string]callbackIncrement{
 		menu.ContextReset()
 		settings.Save()
 	},
+	"VideoIntScaling": func(f *structs.Field, direction int) {
+		v := f.Value().(bool)
+		v = !v
+		f.Set(v)
+		settings.Save()
+	},
 	"VideoMonitorIndex": func(f *structs.Field, direction int) {
 		v := f.Value().(int)
 		v += direction

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -23,6 +23,7 @@ import (
 // Widget sets the graphical representation of the value.
 type Settings struct {
 	VideoFullscreen   bool   `hide:"ludos" toml:"video_fullscreen" label:"Video Fullscreen" fmt:"%t" widget:"switch"`
+	VideoIntScaling   bool   `toml:"video_int_scaling" label:"Video Integer Scaling" fmt:"%t" widget:"switch"`
 	VideoMonitorIndex int    `toml:"video_monitor_index" label:"Video Monitor Index" fmt:"%d"`
 	VideoFilter       string `toml:"video_filter" label:"Video Filter" fmt:"<%s>"`
 	VideoDarkMode     bool   `toml:"video_dark_mode" label:"Video Dark Mode" fmt:"%t" widget:"switch"`

--- a/video/video.go
+++ b/video/video.go
@@ -309,12 +309,41 @@ func (video *Video) coreRatioViewport(fbWidth int, fbHeight int) (x, y, w, h flo
 		aspectRatio = float32(video.Geom.BaseWidth) / float32(video.Geom.BaseHeight)
 	}
 
-	h = fbh
-	w = fbh * aspectRatio
-	if w > fbw {
-		h = fbw / aspectRatio
-		w = fbw
+	// (C) donmor 2022 patch-1 BEGIN
+	if settings.Current.VideoIntScaling {
+		gh := video.Geom.BaseHeight
+		if gh == 0 {
+			gh = fbHeight
+		}
+		scale := fbHeight / gh
+		h = float32(gh * scale)
+		if scale == 0 {
+			h = fbh
+		}
+		w = h * aspectRatio
+		if w > fbw {
+			gw := video.Geom.BaseWidth
+			if gw == 0 {
+				gw = fbWidth
+			}
+			scale = fbWidth / int(float32(gh)*aspectRatio)
+			h = float32(gh * scale)
+			if scale == 0 {
+				h = fbw / aspectRatio
+				w = fbw
+			} else {
+				w = h * aspectRatio
+			}
+		}
+	} else {
+		h = fbh
+		w = fbh * aspectRatio
+		if w > fbw {
+			h = fbw / aspectRatio
+			w = fbw
+		}
 	}
+	// (C) donmor 2022 patch-1 END
 
 	// Place the content in the middle of the window.
 	x = (fbw - w) / 2
@@ -350,7 +379,10 @@ func (video *Video) Render() {
 		return
 	}
 
+	// (C) donmor 2022 patch-1 BEGIN
+	//	fbw, fbh := video.Window.GetFramebufferSize()
 	fbw, fbh := video.Window.GetFramebufferSize()
+	// (C) donmor 2022 patch-1 END
 	_, _, w, h := video.coreRatioViewport(fbw, fbh)
 
 	gl.UseProgram(video.program)


### PR DESCRIPTION
Former issue #483 .
This PR added a feature that making it able to do integer scaling, to achieve "pixel perfect". When option `Settings > Video Integer Scaling` is on, the core renderer detects the window size and scale the original video to the max size while keeping pixel-perfect. An entry added in settings.
![2022-06-17 21-42-50](https://user-images.githubusercontent.com/29735136/174313727-765a7082-c9b5-41bc-b754-8f0a34c40436.png) 
![2022-06-17 21-55-38](https://user-images.githubusercontent.com/29735136/174313680-6afc50b1-baf9-4c00-892f-5847396c7c26.png)
