### PR TITLE
Setting to Swap Confirm and Cancel in menu

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -111,6 +111,7 @@ func unarchiveGame(filename string) (string, int64, error) {
 	extPrefered := make(map[string]int)
 	extPrefered[".cue"] = 1
 	extPrefered[".m3u"] = 2
+	extPrefered[".pbp"] = 3
 
 	err = archiver.Walk(filename, func(f archiver.File) error {
 		fname := f.Name()

--- a/dat/dat.go
+++ b/dat/dat.go
@@ -101,10 +101,13 @@ func (db *DB) FindByROMName(romPath string, romName string, crc uint32, games ch
 					continue
 				}
 				// If the checksums match
-				if romName == game.ROMs[0].Name {
-					game.Path = romPath
-					game.System = system
-					games <- game
+				for _, ROM := range game.ROMs {
+					if romName == ROM.Name {
+						game.Path = romPath
+						game.System = system
+						games <- game
+					}
+					// element is the element from someSlice for where we are
 				}
 			}
 			wg.Done()

--- a/menu/input.go
+++ b/menu/input.go
@@ -85,22 +85,6 @@ func genericInput(list *entry, dt float32) {
 		genericAnimate(list)
 	})
 
-	// OK
-	if input.Released[0][libretro.DeviceIDJoypadA] == 1 {
-		if list.children[list.ptr].callbackOK != nil {
-			audio.PlayEffect(audio.Effects["ok"])
-			list.children[list.ptr].callbackOK()
-		}
-	}
-
-	// X
-	if input.Released[0][libretro.DeviceIDJoypadX] == 1 {
-		if list.children[list.ptr].callbackX != nil {
-			audio.PlayEffect(audio.Effects["ok"])
-			list.children[list.ptr].callbackX()
-		}
-	}
-
 	// Right
 	if input.Released[0][libretro.DeviceIDJoypadRight] == 1 {
 		if list.children[list.ptr].incr != nil {
@@ -117,12 +101,40 @@ func genericInput(list *entry, dt float32) {
 		}
 	}
 
+	var confirmKey uint32
+	var cancelKey uint32
+
+	confirmKey = libretro.DeviceIDJoypadA
+	cancelKey = libretro.DeviceIDJoypadB
+
+	// Optionally swap confirm and cancel
+	if settings.Current.SwapConfirm {
+		confirmKey = libretro.DeviceIDJoypadB
+		cancelKey = libretro.DeviceIDJoypadA
+	}
+
+	// OK
+	if input.Released[0][confirmKey] == 1 {
+		if list.children[list.ptr].callbackOK != nil {
+			audio.PlayEffect(audio.Effects["ok"])
+			list.children[list.ptr].callbackOK()
+		}
+	}
+
 	// Cancel
-	if input.Released[0][libretro.DeviceIDJoypadB] == 1 {
+	if input.Released[0][cancelKey] == 1 {
 		if len(menu.stack) > 1 {
 			audio.PlayEffect(audio.Effects["cancel"])
 			menu.stack[len(menu.stack)-2].segueBack()
 			menu.stack = menu.stack[:len(menu.stack)-1]
+		}
+	}
+
+	// X
+	if input.Released[0][libretro.DeviceIDJoypadX] == 1 {
+		if list.children[list.ptr].callbackX != nil {
+			audio.PlayEffect(audio.Effects["ok"])
+			list.children[list.ptr].callbackX()
 		}
 	}
 

--- a/menu/scene.go
+++ b/menu/scene.go
@@ -2,6 +2,7 @@ package menu
 
 import (
 	"github.com/libretro/ludo/state"
+	"github.com/libretro/ludo/settings"
 	"github.com/tanema/gween"
 	"github.com/tanema/gween/ease"
 )
@@ -273,6 +274,12 @@ func genericDrawHintBar() {
 		stackHint(&stack, guide, "RESUME", h)
 	}
 	stackHint(&stack, upDown, "NAVIGATE", h)
-	stackHint(&stack, b, "BACK", h)
-	stackHint(&stack, a, "OK", h)
+
+	if settings.Current.SwapConfirm {
+		stackHint(&stack, b, "OK", h)
+        stackHint(&stack, a, "BACK", h)
+	} else {
+		stackHint(&stack, a, "OPEN", h)
+        stackHint(&stack, b, "OK", h)
+	}
 }

--- a/menu/scene_core_disk_control.go
+++ b/menu/scene_core_disk_control.go
@@ -5,6 +5,7 @@ import (
 
 	ntf "github.com/libretro/ludo/notifications"
 	"github.com/libretro/ludo/state"
+	"github.com/libretro/ludo/settings"
 )
 
 type sceneCoreDiskControl struct {
@@ -79,13 +80,19 @@ func (s *sceneCoreDiskControl) drawHintBar() {
 	w, h := menu.GetFramebufferSize()
 	menu.DrawRect(0, float32(h)-70*menu.ratio, float32(w), 70*menu.ratio, 0, lightGrey)
 
-	_, upDown, leftRight, _, b, _, _, _, _, guide := hintIcons()
+	_, upDown, leftRight, a, b, _, _, _, _, guide := hintIcons()
 
 	var stack float32
 	if state.CoreRunning {
 		stackHint(&stack, guide, "RESUME", h)
 	}
 	stackHint(&stack, upDown, "NAVIGATE", h)
-	stackHint(&stack, b, "BACK", h)
+
+	if settings.Current.SwapConfirm {
+		stackHint(&stack, a, "BACK", h)
+	} else {
+		stackHint(&stack, b, "BACK", h)
+	}
+	
 	stackHint(&stack, leftRight, "SET", h)
 }

--- a/menu/scene_core_options.go
+++ b/menu/scene_core_options.go
@@ -6,6 +6,7 @@ import (
 	"github.com/libretro/ludo/core"
 	ntf "github.com/libretro/ludo/notifications"
 	"github.com/libretro/ludo/state"
+	"github.com/libretro/ludo/settings"
 )
 
 type sceneCoreOptions struct {
@@ -83,13 +84,17 @@ func (s *sceneCoreOptions) drawHintBar() {
 	w, h := menu.GetFramebufferSize()
 	menu.DrawRect(0, float32(h)-70*menu.ratio, float32(w), 70*menu.ratio, 0, lightGrey)
 
-	_, upDown, leftRight, _, b, _, _, _, _, guide := hintIcons()
+	_, upDown, leftRight, a, b, _, _, _, _, guide := hintIcons()
 
 	var stack float32
 	if state.CoreRunning {
 		stackHint(&stack, guide, "RESUME", h)
 	}
 	stackHint(&stack, upDown, "NAVIGATE", h)
-	stackHint(&stack, b, "BACK", h)
+	if settings.Current.SwapConfirm {
+        stackHint(&stack, a, "BACK", h)
+	} else {
+        stackHint(&stack, b, "BACK", h)
+	}
 	stackHint(&stack, leftRight, "SET", h)
 }

--- a/menu/scene_dialog.go
+++ b/menu/scene_dialog.go
@@ -4,6 +4,7 @@ import (
 	"github.com/libretro/ludo/audio"
 	"github.com/libretro/ludo/input"
 	"github.com/libretro/ludo/libretro"
+	"github.com/libretro/ludo/settings"
 )
 
 type sceneDialog struct {
@@ -36,8 +37,20 @@ func (s *sceneDialog) segueBack() {
 }
 
 func (s *sceneDialog) update(dt float32) {
+	var confirmKey uint32
+	var cancelKey uint32
+
+	confirmKey = libretro.DeviceIDJoypadA
+	cancelKey = libretro.DeviceIDJoypadB
+
+	// Optionally swap confirm and cancel
+	if settings.Current.SwapConfirm {
+		confirmKey = libretro.DeviceIDJoypadB
+		cancelKey = libretro.DeviceIDJoypadA
+	}
+
 	// OK
-	if input.Released[0][libretro.DeviceIDJoypadA] == 1 {
+	if input.Released[0][confirmKey] == 1 {
 		audio.PlayEffect(audio.Effects["ok"])
 		menu.stack[len(menu.stack)-2].segueBack()
 		menu.stack = menu.stack[:len(menu.stack)-1]
@@ -45,7 +58,7 @@ func (s *sceneDialog) update(dt float32) {
 	}
 
 	// Cancel
-	if input.Released[0][libretro.DeviceIDJoypadB] == 1 {
+	if input.Released[0][cancelKey] == 1 {
 		audio.PlayEffect(audio.Effects["cancel"])
 		menu.stack[len(menu.stack)-2].segueBack()
 		menu.stack = menu.stack[:len(menu.stack)-1]

--- a/menu/scene_history.go
+++ b/menu/scene_history.go
@@ -8,6 +8,7 @@ import (
 	"github.com/libretro/ludo/history"
 	ntf "github.com/libretro/ludo/notifications"
 	"github.com/libretro/ludo/state"
+	"github.com/libretro/ludo/settings"
 )
 
 type sceneHistory struct {
@@ -242,8 +243,14 @@ func (s *sceneHistory) drawHintBar() {
 		stackHint(&stack, guide, "RESUME", h)
 	}
 	stackHint(&stack, upDown, "NAVIGATE", h)
-	stackHint(&stack, b, "BACK", h)
-	stackHint(&stack, a, "RUN", h)
+	
+	if settings.Current.SwapConfirm {
+		stackHint(&stack, b, "RUN", h)
+        stackHint(&stack, a, "BACK", h)
+	} else {
+		stackHint(&stack, a, "RUN", h)
+        stackHint(&stack, b, "BACK", h)
+	}
 
 	list := menu.stack[len(menu.stack)-1].Entry()
 	if list.children[list.ptr].callbackX != nil {

--- a/menu/scene_keyboard.go
+++ b/menu/scene_keyboard.go
@@ -5,6 +5,7 @@ import (
 	"github.com/libretro/ludo/input"
 	"github.com/libretro/ludo/libretro"
 	"github.com/libretro/ludo/video"
+	"github.com/libretro/ludo/settings"
 	"github.com/tanema/gween"
 	"github.com/tanema/gween/ease"
 )
@@ -109,10 +110,29 @@ func (s *sceneKeyboard) update(dt float32) {
 		}
 	})
 
+	var confirmKey uint32
+	var cancelKey uint32
+
+	confirmKey = libretro.DeviceIDJoypadA
+	cancelKey = libretro.DeviceIDJoypadB
+
+	// Optionally swap confirm and cancel
+	if settings.Current.SwapConfirm {
+		confirmKey = libretro.DeviceIDJoypadB
+		cancelKey = libretro.DeviceIDJoypadA
+	}
+
 	// OK
-	if input.Released[0][libretro.DeviceIDJoypadA] == 1 {
+	if input.Released[0][confirmKey] == 1 {
 		audio.PlayEffect(audio.Effects["ok"])
 		s.value += layouts[s.layout][s.index]
+	}
+
+	// Cancel
+	if input.Released[0][cancelKey] == 1 && len(menu.stack) > 1 {
+		audio.PlayEffect(audio.Effects["cancel"])
+		menu.stack[len(menu.stack)-2].segueBack()
+		menu.stack = menu.stack[:len(menu.stack)-1]
 	}
 
 	// Switch layout
@@ -131,13 +151,6 @@ func (s *sceneKeyboard) update(dt float32) {
 			s.value = s.value[:len(s.value)-1]
 		}
 	})
-
-	// Cancel
-	if input.Released[0][libretro.DeviceIDJoypadB] == 1 && len(menu.stack) > 1 {
-		audio.PlayEffect(audio.Effects["cancel"])
-		menu.stack[len(menu.stack)-2].segueBack()
-		menu.stack = menu.stack[:len(menu.stack)-1]
-	}
 
 	// Done
 	if input.Released[0][libretro.DeviceIDJoypadStart] == 1 && s.value != "" {

--- a/menu/scene_playlist.go
+++ b/menu/scene_playlist.go
@@ -275,8 +275,14 @@ func (s *scenePlaylist) drawHintBar() {
 		stackHint(&stack, guide, "RESUME", h)
 	}
 	stackHint(&stack, upDown, "NAVIGATE", h)
-	stackHint(&stack, b, "BACK", h)
-	stackHint(&stack, a, "RUN", h)
+
+	if settings.Current.SwapConfirm {
+		stackHint(&stack, b, "RUN", h)
+        stackHint(&stack, a, "BACK", h)
+	} else {
+		stackHint(&stack, a, "RUN", h)
+        stackHint(&stack, b, "BACK", h)
+	}
 
 	list := menu.stack[len(menu.stack)-1].Entry()
 	if list.children[list.ptr].callbackX != nil {

--- a/menu/scene_playlist.go
+++ b/menu/scene_playlist.go
@@ -26,6 +26,11 @@ func buildPlaylist(path string) Scene {
 	for _, game := range playlists.Playlists[path] {
 		game := game // needed for callbackOK
 		strippedName, tags := extractTags(game.Name)
+		if strings.Contains(game.Name, "Disc") {
+			re := regexp.MustCompile(`\((Disc [1-9]?)\)`)
+			match := re.FindStringSubmatch(game.Name)
+			strippedName = strippedName + " (" + match[1] + ")"
+		}
 		list.children = append(list.children, entry{
 			label:      strippedName,
 			gameName:   game.Name,

--- a/menu/scene_savestates.go
+++ b/menu/scene_savestates.go
@@ -175,11 +175,25 @@ func (s *sceneSavestates) drawHintBar() {
 		stackHint(&stack, guide, "RESUME", h)
 	}
 	stackHint(&stack, upDown, "NAVIGATE", h)
-	stackHint(&stack, b, "BACK", h)
-	if ptr == 0 {
-		stackHint(&stack, a, "SAVE", h)
+
+	if settings.Current.SwapConfirm {
+        stackHint(&stack, a, "BACK", h)
 	} else {
-		stackHint(&stack, a, "LOAD", h)
+        stackHint(&stack, b, "BACK", h)
+	}
+
+	if settings.Current.SwapConfirm {
+		if ptr == 0 {
+			stackHint(&stack, b, "SAVE", h)
+		} else {
+			stackHint(&stack, b, "LOAD", h)
+		}
+	} else {
+		if ptr == 0 {
+			stackHint(&stack, a, "SAVE", h)
+		} else {
+			stackHint(&stack, a, "LOAD", h)
+		}		
 	}
 
 	list := menu.stack[len(menu.stack)-1].Entry()

--- a/menu/scene_settings.go
+++ b/menu/scene_settings.go
@@ -284,9 +284,20 @@ func (s *sceneSettings) drawHintBar() {
 		stackHint(&stack, guide, "RESUME", h)
 	}
 	stackHint(&stack, upDown, "NAVIGATE", h)
-	stackHint(&stack, b, "BACK", h)
+
+	if settings.Current.SwapConfirm {
+        stackHint(&stack, a, "BACK", h)
+	} else {
+        stackHint(&stack, b, "BACK", h)
+	}
+
+
 	if list.children[list.ptr].callbackOK != nil {
-		stackHint(&stack, a, "SET", h)
+		if settings.Current.SwapConfirm {
+			stackHint(&stack, b, "SET", h)
+		} else {
+			stackHint(&stack, a, "SET", h)
+		}
 	} else {
 		stackHint(&stack, leftRight, "SET", h)
 	}

--- a/menu/scene_settings.go
+++ b/menu/scene_settings.go
@@ -209,6 +209,12 @@ var incrCallbacks = map[string]callbackIncrement{
 		f.Set(v)
 		settings.Save()
 	},
+	"SwapConfirm": func(f *structs.Field, direction int) {
+		v := f.Value().(bool)
+		v = !v
+		f.Set(v)
+		settings.Save()
+	},
 	"AudioVolume": func(f *structs.Field, direction int) {
 		v := f.Value().(float32)
 		v += 0.1 * float32(direction)

--- a/menu/scene_tabs.go
+++ b/menu/scene_tabs.go
@@ -263,8 +263,17 @@ func (tabs *sceneTabs) update(dt float32) {
 		tabs.animate()
 	})
 
+	var confirmKey uint32
+
+	confirmKey = libretro.DeviceIDJoypadA
+
+	// Optionally swap confirm and cancel
+	if settings.Current.SwapConfirm {
+		confirmKey = libretro.DeviceIDJoypadB
+	}
+
 	// OK
-	if input.Released[0][libretro.DeviceIDJoypadA] == 1 {
+	if input.Released[0][confirmKey] == 1 {
 		if tabs.children[tabs.ptr].callbackOK != nil {
 			audio.PlayEffect(audio.Effects["ok"])
 			tabs.segueNext()
@@ -315,15 +324,18 @@ func (tabs sceneTabs) drawHintBar() {
 	w, h := menu.GetFramebufferSize()
 	menu.DrawRect(0, float32(h)-70*menu.ratio, float32(w), 70*menu.ratio, 0, lightGrey)
 
-	_, _, leftRight, a, _, x, _, _, _, guide := hintIcons()
+	_, _, leftRight, a, b, x, _, _, _, guide := hintIcons()
 
 	var stack float32
 	if state.CoreRunning {
 		stackHint(&stack, guide, "RESUME", h)
 	}
 	stackHint(&stack, leftRight, "NAVIGATE", h)
-	stackHint(&stack, a, "OPEN", h)
-
+	if settings.Current.SwapConfirm {
+		stackHint(&stack, b, "OPEN", h)
+	} else {
+		stackHint(&stack, a, "OPEN", h)
+	}
 	list := menu.stack[0].Entry()
 	if list.children[list.ptr].callbackX != nil {
 		stackHint(&stack, x, "DELETE", h)

--- a/menu/scene_tabs.go
+++ b/menu/scene_tabs.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"fmt"
 	"os"
-	"os/user"
+	//"os/user"
 	"sort"
 
 	"github.com/libretro/ludo/audio"
@@ -15,6 +15,7 @@ import (
 	"github.com/libretro/ludo/state"
 	"github.com/libretro/ludo/utils"
 	"github.com/libretro/ludo/video"
+	"github.com/libretro/ludo/settings"
 	colorful "github.com/lucasb-eyer/go-colorful"
 
 	"github.com/tanema/gween"
@@ -63,8 +64,8 @@ func buildTabs() Scene {
 		subLabel: "Scan your collection",
 		icon:     "add",
 		callbackOK: func() {
-			usr, _ := user.Current()
-			menu.Push(buildExplorer(usr.HomeDir, nil,
+			//usr, _ := user.Current()
+			menu.Push(buildExplorer(settings.Current.FileDirectory, nil,
 				func(path string) {
 					scanner.ScanDir(path, refreshTabs)
 				},

--- a/menu/scene_wifi.go
+++ b/menu/scene_wifi.go
@@ -2,6 +2,7 @@ package menu
 
 import (
 	"github.com/libretro/ludo/ludos"
+	"github.com/libretro/ludo/settings"
 	ntf "github.com/libretro/ludo/notifications"
 )
 
@@ -92,8 +93,17 @@ func (s *sceneWiFi) drawHintBar() {
 
 	var stack float32
 	stackHint(&stack, upDown, "NAVIGATE", h)
-	stackHint(&stack, b, "BACK", h)
+
+	if settings.Current.SwapConfirm {
+		stackHint(&stack, a, "BACK", h)
+	} else {
+		stackHint(&stack, b, "BACK", h)
+	}
 	if s.children[0].callbackOK != nil {
-		stackHint(&stack, a, "CONNECT", h)
+		if settings.Current.SwapConfirm {
+			stackHint(&stack, b, "CONNECT", h)
+		} else {
+			stackHint(&stack, a, "CONNECT", h)
+		}
 	}
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -134,7 +134,7 @@ func Scan(dir string, roms []string, games chan (dat.Game), n *ntf.Notification)
 		case ".cue", ".pbp":
 			// Look for a matching game entry in the database
 			state.DB.FindByROMName(f, filepath.Base(f), 0, games)
-			n.Update(ntf.Info, strconv.Itoa(i)+"/"+strconv.Itoa(len(roms))+" "+f)		
+			n.Update(ntf.Info, strconv.Itoa(i)+"/"+strconv.Itoa(len(roms))+" "+f)
 		case ".32x", "a52", ".a78", ".col", ".crt", ".d64", ".pce", ".fds", ".gb", ".gba", ".gbc", ".gen", ".gg", ".ipf", ".j64", ".jag", ".lnx", ".md", ".n64", ".nes", ".ngc", ".nds", ".rom", ".sfc", ".sg", ".smc", ".smd", ".sms", ".ws", ".wsc":
 			bytes, err := ioutil.ReadFile(f)
 			if err != nil {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -135,6 +135,10 @@ func Scan(dir string, roms []string, games chan (dat.Game), n *ntf.Notification)
 			// Look for a matching game entry in the database
 			state.DB.FindByROMName(f, filepath.Base(f), 0, games)
 			n.Update(ntf.Info, strconv.Itoa(i)+"/"+strconv.Itoa(len(roms))+" "+f)
+		case ".pbp":
+			// Look for a matching game entry in the database
+			state.DB.FindByROMName(f, filepath.Base(f), 0, games)
+			n.Update(ntf.Info, strconv.Itoa(i)+"/"+strconv.Itoa(len(roms))+" "+f)			
 		case ".32x", "a52", ".a78", ".col", ".crt", ".d64", ".pce", ".fds", ".gb", ".gba", ".gbc", ".gen", ".gg", ".ipf", ".j64", ".jag", ".lnx", ".md", ".n64", ".nes", ".ngc", ".nds", ".rom", ".sfc", ".sg", ".smc", ".smd", ".sms", ".ws", ".wsc":
 			bytes, err := ioutil.ReadFile(f)
 			if err != nil {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-
 	"github.com/libretro/ludo/dat"
 	ntf "github.com/libretro/ludo/notifications"
 	"github.com/libretro/ludo/playlists"
@@ -131,7 +130,7 @@ func Scan(dir string, roms []string, games chan (dat.Game), n *ntf.Notification)
 				}
 			}
 			z.Close()
-		case ".cue", ".pbp":
+		case ".cue", ".pbp", ".m3u":
 			// Look for a matching game entry in the database
 			state.DB.FindByROMName(f, filepath.Base(f), 0, games)
 			n.Update(ntf.Info, strconv.Itoa(i)+"/"+strconv.Itoa(len(roms))+" "+f)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -131,14 +131,10 @@ func Scan(dir string, roms []string, games chan (dat.Game), n *ntf.Notification)
 				}
 			}
 			z.Close()
-		case ".cue":
+		case ".cue", ".pbp":
 			// Look for a matching game entry in the database
 			state.DB.FindByROMName(f, filepath.Base(f), 0, games)
-			n.Update(ntf.Info, strconv.Itoa(i)+"/"+strconv.Itoa(len(roms))+" "+f)
-		case ".pbp":
-			// Look for a matching game entry in the database
-			state.DB.FindByROMName(f, filepath.Base(f), 0, games)
-			n.Update(ntf.Info, strconv.Itoa(i)+"/"+strconv.Itoa(len(roms))+" "+f)			
+			n.Update(ntf.Info, strconv.Itoa(i)+"/"+strconv.Itoa(len(roms))+" "+f)		
 		case ".32x", "a52", ".a78", ".col", ".crt", ".d64", ".pce", ".fds", ".gb", ".gba", ".gbc", ".gen", ".gg", ".ipf", ".j64", ".jag", ".lnx", ".md", ".n64", ".nes", ".ngc", ".nds", ".rom", ".sfc", ".sg", ".smc", ".smd", ".sms", ".ws", ".wsc":
 			bytes, err := ioutil.ReadFile(f)
 			if err != nil {

--- a/settings/defaults.go
+++ b/settings/defaults.go
@@ -12,6 +12,7 @@ func defaultSettings() Settings {
 		VideoMonitorIndex: 0,
 		VideoFilter:       "Pixel Perfect",
 		MapAxisToDPad:     false,
+		SwapConfirm:       false,
 		AudioVolume:       0.5,
 		MenuAudioVolume:   0.25,
 		ShowHiddenFiles:   false,

--- a/settings/defaults.go
+++ b/settings/defaults.go
@@ -58,6 +58,7 @@ func defaultSettings() Settings {
 			"SNK - Neo Geo Pocket":                           "mednafen_ngp_libretro",
 			"Sony - PlayStation":                             playstationCore,
 		},
+		FileDirectory:        xdg.DataHome,
 		CoresDirectory:       "./cores",
 		AssetsDirectory:      "./assets",
 		DatabaseDirectory:    "./database",

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -33,6 +33,7 @@ type Settings struct {
 	ShowHiddenFiles bool    `toml:"menu_showhiddenfiles" label:"Show Hidden Files" fmt:"%t" widget:"switch"`
 
 	MapAxisToDPad bool `toml:"input_map_axis_to_dpad" label:"Map Sticks To DPad" fmt:"%t" widget:"switch"`
+	SwapConfirm bool `toml:"input_swap_confirm" label:"Swap Confirm and Cancel" fmt:"%t" widget:"switch"`
 
 	CoreForPlaylist map[string]string `hide:"always" toml:"core_for_playlist"`
 

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -36,6 +36,7 @@ type Settings struct {
 
 	CoreForPlaylist map[string]string `hide:"always" toml:"core_for_playlist"`
 
+	FileDirectory        string `hide:"ludos" toml:"files_dir" label:"Files Directory" fmt:"%s" widget:"dir"`
 	CoresDirectory       string `hide:"ludos" toml:"cores_dir" label:"Cores Directory" fmt:"%s" widget:"dir"`
 	AssetsDirectory      string `hide:"ludos" toml:"assets_dir" label:"Assets Directory" fmt:"%s" widget:"dir"`
 	DatabaseDirectory    string `hide:"ludos" toml:"database_dir" label:"Database Directory" fmt:"%s" widget:"dir"`


### PR DESCRIPTION
Many people has strong associations with which face buttons will act as Confirm and Cancel with two typical layouts:

* Japanese: Bottom button cancels, right button confirms.
* Western: Bottom button confirms, right button cancels.

Previously ludo defaulted to the Japanese layout with no convenient means of swapping them. This pull request does the following:

* Adds the toggle `Settings > Swap Confirm and Cancel`
* When this toggle is set to true, input handling is switched to the Western layout.
* Hints update for gamepad or keyboard.

This would address libretro/ludo#501 and also includes the fixes included in libretro/ludo#521.