### PR TITLE
Enable mupen64plus on all platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifeq ($(OS), Linux)
 	BUNDLENAME = $(APP)-$(OS)-$(DISPDRIVER)-$(ARCH)-$(VERSION)
 endif
 
-CORES = atari800 bluemsx swanstation fbneo fceumm gambatte gearsystem genesis_plus_gx handy lutro mednafen_ngp mednafen_pce mednafen_pce_fast mednafen_pcfx mednafen_psx mednafen_saturn mednafen_supergrafx mednafen_vb mednafen_wswan mgba melonds np2kai o2em pcsx_rearmed picodrive pokemini prosystem snes9x stella2014 vecx virtualjaguar
+CORES = atari800 bluemsx swanstation fbneo fceumm gambatte gearsystem genesis_plus_gx handy lutro mednafen_ngp mednafen_pce mednafen_pce_fast mednafen_pcfx mednafen_psx mednafen_saturn mednafen_supergrafx mednafen_vb mednafen_wswan mgba melonds mupen64plus_next np2kai o2em pcsx_rearmed picodrive pokemini prosystem snes9x stella2014 vecx virtualjaguar
 
 ifeq ($(ARCH), arm)
 	CORES := $(filter-out swanstation,$(CORES))
@@ -23,10 +23,6 @@ ifeq ($(ARCH), arm64)
 	CORES := $(filter-out mednafen_wswan,$(CORES))
 	CORES := $(filter-out handy,$(CORES))
 	CORES := $(filter-out np2kai,$(CORES))
-endif
-
-ifeq ($(OS), Windows)
-	CORES += mupen64plus_next
 endif
 
 DYLIBS = $(addprefix cores/, $(addsuffix _libretro.dylib,$(CORES)))


### PR DESCRIPTION
I recently noticed that the core was now able to run out of the box on ludo on linux.