### PR TITLE
fix: NPE when game has "Disc" in name

### DIFF
--- a/menu/scene_playlist.go
+++ b/menu/scene_playlist.go
@@ -23,12 +23,11 @@ func buildPlaylist(path string) Scene {
 	var list scenePlaylist
 	list.label = utils.FileName(path)
 
+	re := regexp.MustCompile(`\(([Dd]isc [1-9]?)\)`)
 	for _, game := range playlists.Playlists[path] {
 		game := game // needed for callbackOK
 		strippedName, tags := extractTags(game.Name)
-		if strings.Contains(game.Name, "Disc") {
-			re := regexp.MustCompile(`\((Disc [1-9]?)\)`)
-			match := re.FindStringSubmatch(game.Name)
+		if match := re.FindStringSubmatch(game.Name); len(match) >= 2 {
 			strippedName = strippedName + " (" + match[1] + ")"
 		}
 		list.children = append(list.children, entry{


### PR DESCRIPTION
If you have any game with the substring `Disc` that doesn't match `(Disc [0-9])` Ludo will crash.
In my case I found out by accident because I had this SNES game:
`Mickey's Playtown Adventure - A Day of Discovery! (USA) (Proto)`
