### PR TITLE
fix: ignore zero or empty CRC and check file size

### DIFF
--- a/dat/dat.go
+++ b/dat/dat.go
@@ -36,6 +36,7 @@ type CRC uint32
 type ROM struct {
 	XMLName xml.Name `xml:"rom"`
 	Name    string   `xml:"name,attr"`
+	Size    int64    `xml:"size,attr"`
 	CRC     CRC      `xml:"crc,attr"`
 }
 
@@ -63,7 +64,12 @@ func Parse(dat []byte) Dat {
 }
 
 // FindByCRC loops over the Dats in the DB and concurrently matches CRC checksums.
-func (db *DB) FindByCRC(romPath string, romName string, crc uint32, games chan (Game)) {
+func (db *DB) FindByCRC(romPath string, romName string, crc uint32, size int64, games chan (Game)) {
+	// skip empty file
+	if size == 0 || crc == 0 {
+		return
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(len(*db))
 	// For every Dat in the DB
@@ -74,8 +80,8 @@ func (db *DB) FindByCRC(romPath string, romName string, crc uint32, games chan (
 				if len(game.ROMs) == 0 {
 					continue
 				}
-				// If the checksums match
-				if crc == uint32(game.ROMs[0].CRC) {
+				// If the checksums and sizes match
+				if crc == uint32(game.ROMs[0].CRC) && size == game.ROMs[0].Size {
 					game.Path = romPath
 					game.System = system
 					games <- game


### PR DESCRIPTION
An empty file was matching ~11k games because the games didn't have a CRC attribute, so the zero value, `0`, was being matched by an empty file CRC, which is also `0`.

For example: I have only one PSX game, but a random file called "SUPER MARIO KART 8.smc" with 0 KB was being scanned and matched by 9K games with unknown CRC, plus other 2k games from N64 and other consoles.

![image](https://github.com/libretro/ludo/assets/85039990/f13c6ac3-f856-4ddf-abf2-e9efc4d34de4)
